### PR TITLE
Removed FORTIFY_SOURCE=2 from Debug build

### DIFF
--- a/cmake/IncludePackages.cmake
+++ b/cmake/IncludePackages.cmake
@@ -41,7 +41,10 @@ IF(YARS_USE_VISUALISATION)
   include_directories(${OGRE_INCLUDE_DIR})
 
   if(UNIX AND NOT APPLE)
-    add_definitions(-pthread -D_FORTIFY_SOURCE=2)
+    add_definitions(-pthread)
+    if(CMAKE_BUILD_TYPE MATCHES Release)
+      add_definitions(-D_FORTIFY_SOURCE=2)
+    endif(CMAKE_BUILD_TYPE MATCHES Release)
   endif(UNIX AND NOT APPLE)
 ENDIF(YARS_USE_VISUALISATION)
 

--- a/src/yars/configuration/data/DataRobotSimulationDescription.cpp
+++ b/src/yars/configuration/data/DataRobotSimulationDescription.cpp
@@ -28,7 +28,6 @@ DataRobotSimulationDescription::DataRobotSimulationDescription(DataNode*)
   _geoms       = new DataObjects();
   _sensors     = new DataSensors();
   _actuators   = new DataActuators();
-  _sensors     = new DataSensors();
   _controllers = new DataControllers();
 
   current      = this;


### PR DESCRIPTION
FORTIFY_SOURCE has some issues with the Debug build (needs optimization). This enables it only for the Release build.