### PR TITLE
Shadow resolution: 4096² map + 16m frustum

### DIFF
--- a/docs/planning/shadows_state.md
+++ b/docs/planning/shadows_state.md
@@ -7,7 +7,7 @@ non-floor receivers** via Ogre's `SHADOWTYPE_TEXTURE_MODULATIVE`
 framework with custom GLSL caster + receiver shaders.
 
 **Architecture.** Texture-based shadow mapping. Ogre renders all casters
-to a 2048×2048 `PF_FLOAT32_R` shadow texture from the light's POV (one
+to a 4096×4096 `PF_FLOAT32_R` shadow texture from the light's POV (one
 ortho camera produced by `YarsFixedShadowCameraSetup` aligned to the
 directional light at `(-1,-1,-1)`), then re-renders every receiver in a
 second modulating pass that samples the shadow texture and darkens
@@ -53,10 +53,14 @@ shadowed fragments.
 5. **Shadow camera setup.** `YarsFixedShadowCameraSetup`
    (`OgreHandler.cpp:39`) — world-anchored and light-aligned, ignoring
    the eye camera entirely. It positions an ortho camera along
-   `-lightDir` looking at the origin with a fixed 60×60 frustum
-   (half-extent 30 m, `OgreHandler.cpp:98`). This guarantees full-arena
-   coverage in **every** scene and removes camera-dependent drift. At
-   2048² that is ~2.9 cm/texel, smoothed by PCF. (Replaced
+   `-lightDir` looking at the origin with a fixed 32×32 frustum
+   (half-extent 16 m — casters in all shipped scenes live within ±15 m;
+   the ground plane is receiver-only and may extend past the frustum).
+   This covers every shipped scene's casters and removes
+   camera-dependent drift. At 4096² that is ~0.78 cm/texel, smoothed by
+   PCF. (Tightened 2026-07-04 from 60×60 @ 2048² — ~2.9 cm/texel made
+   thin casters like the hexapod antennae drop below one texel,
+   producing dashed, stair-stepped shadows.) (Replaced
    `FocusedShadowCameraSetup`, which fit the frustum to the *viewer's*
    view — sparse-caster scenes like `falling_objects.xml` got a tight
    frustum that missed most of the floor, and coverage drifted when
@@ -68,8 +72,8 @@ shadowed fragments.
 |-------|-------|--------------|
 | `shadowDarkness` | 0.35 | Modulation factor in `shadow_receiver.frag` |
 | `shadowBias` | 0.0002 | Depth-compare offset vs. acne (~4 cm world over the 1..200 frustum, with float depth) |
-| Shadow texture | 2048², `PF_FLOAT32_R` | Resolution / format (float depth — 8-bit `PF_R8G8B8` gave only 256 levels and lost subtle shadows) |
-| Fixed frustum half-extent | 30 m (60×60) | `YarsFixedShadowCameraSetup`, `OgreHandler.cpp:98` |
+| Shadow texture | 4096², `PF_FLOAT32_R` | Resolution / format (float depth — 8-bit `PF_R8G8B8` gave only 256 levels and lost subtle shadows) |
+| Fixed frustum half-extent | 16 m (32×32) | `YarsFixedShadowCameraSetup`, `OgreHandler.cpp` — casters in all shipped scenes live within ±15 m; the ground plane is receiver-only, so it may extend past the frustum (border taps return lit) |
 | `SceneManager::setShadowFarDistance` | 100m | Eye-camera cull distance for the modulating pass only (no longer shapes the shadow camera) |
 | `setShadowCasterRenderBackFaces` | false | Front-face-only casters (prevents self-shadow on receivers) |
 | PCF kernel | 3×3 (9-tap) | Soft penumbra edges in `shadow_receiver.frag` |

--- a/src/yars/view/gui/OgreHandler.cpp
+++ b/src/yars/view/gui/OgreHandler.cpp
@@ -31,8 +31,8 @@ namespace yars {
 //  - Light direction is HARDCODED to (-1, -1, -1) (Ogre world space).
 //  - Shadow camera is positioned at +50 units in the opposite light
 //    direction, looking toward world origin.
-//  - Orthographic frustum of 60×60 covers the hardcoded 50×50 ground
-//    plane's caster-relevant area plus margin for dynamic objects.
+//  - Orthographic frustum of 32×32 covers the caster-relevant area of
+//    all shipped scenes (±15 m) plus margin for dynamic objects.
 //
 // This produces stable, world-anchored shadows that don't move with the
 // camera and reliably align with caster geometry.
@@ -90,13 +90,15 @@ public:
     view[1][3] = -localY.dotProduct(camPos);
     view[2][3] = -localZ.dotProduct(camPos);
 
-    // Orthographic projection. Half-extent 30 m covers the hardcoded
-    // 50×50 ground plane's caster-relevant area (see the createPlane call
-    // in SceneGraphEnvironmentNode.cpp) with margin; casters in all shipped
-    // scenes live well inside ±15 m of the origin. At 2048² that is ~2.9
-    // cm/texel, smoothed by PCF in the receiver.
-    const Ogre::Real halfWidth = 30.0f;
-    const Ogre::Real halfHeight = 30.0f;
+    // Orthographic projection. Half-extent 16 m covers the caster-relevant
+    // area: casters in all shipped scenes live well inside ±15 m of the
+    // origin (the 50×50 ground plane is a receiver only — receivers outside
+    // the frustum sample the border colour and stay lit). At 4096² this is
+    // ~0.78 cm/texel, smoothed by PCF in the receiver. The previous 30 m /
+    // 2048² combination (~2.9 cm/texel) made thin casters (hexapod antennae,
+    // ~1 cm) drop below one texel, producing dashed, stair-stepped shadows.
+    const Ogre::Real halfWidth = 16.0f;
+    const Ogre::Real halfHeight = 16.0f;
     const Ogre::Real n = 1.0f;
     const Ogre::Real f = 200.0f;
     // NOTE: shadowBias in YARSShadowReceiver.material is calibrated to this 1..200 range.
@@ -456,7 +458,7 @@ void OgreHandler::__setupShadows()
   try
   {
     _sceneManager->setShadowTechnique(Ogre::SHADOWTYPE_TEXTURE_MODULATIVE);
-    _sceneManager->setShadowTextureSize(2048);
+    _sceneManager->setShadowTextureSize(4096);
     _sceneManager->setShadowTextureCount(1);
     // Receiver-pass cull distance from the EYE camera. With the fixed
     // shadow frustum this no longer shapes the shadow camera — it only


### PR DESCRIPTION
Fixes rough, stair-stepped shadow edges reported after shadows v6.1 merged (#11).

**Root cause:** 60×60m shadow frustum at 2048² = ~2.9cm/texel. Thin casters (hexapod antennae, ~1cm) fell below one texel — dashed, blocky shadows.

**Fix:** frustum half-extent 30m → 16m (all shipped scenes' casters live within ±15m; ground plane is receiver-only, border PCF taps return lit) and shadow texture 2048² → 4096². Net: ~0.78cm/texel, ~3.75× linear improvement.

**Verified locally (macOS arm64):** hexapod antenna shadows continuous, silhouette + obstacle-face edges clean; braitenberg and falling_objects unchanged; yars_tests 35/35; braitenberg_logging CSV byte-exact vs reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)