### PR TITLE
Fix PNG frame export: --framesDirectory was dead code without USE_CAPTURE_VIDEO

### DIFF
--- a/docs/planning/v0.8.7-open-points.md
+++ b/docs/planning/v0.8.7-open-points.md
@@ -218,16 +218,14 @@ Still-warning items, non-fatal:
   5. build, smoke-test braitenberg_logging.xml in both `--nogui`
      and GUI, run yars_tests, compare sensor lines
 
-- **PNG frame export is non-functional (found 2026-07-06).** Both
-  `--framesDirectory <dir>` and the validate-render skill procedure
-  produce zero frames on macOS arm64, on trees with and without the
-  2026-07 hardening changes (pre-existing). The auto-enable plumbing
-  (`SdlWindow.cpp:90-94`, `ProgramOptions.cpp:187`) looks correct, so
-  suspect init ordering (SdlWindow constructed before the option is
-  applied) or `__YARS_GET_FRAMES_DIRECTORY` reading a different
-  container. Affects the project's visual-validation workflow
-  (validate-render skill, CLAUDE.md image-export instruction) — worth
-  a dedicated fix task.
+- ~~PNG frame export is non-functional~~ **Fixed 2026-07-07** (branch
+  `fix/frame-export`). Root cause was neither init ordering nor a
+  container mismatch: the `--framesDirectory` apply line in
+  `ProgramOptions::__parseProgramOptionsParameters` sat inside
+  `#if USE_CAPTURE_VIDEO`, which is OFF by default — the option was
+  silently discarded on every default build. PNG export is independent
+  of the FFmpeg pipeline; the line now lives outside the guard.
+  Visual verification works again (validate-render skill usable).
 
 - **Sanitize job runs against Ubuntu's Bullet 3.06, not the vendored
   3.25** (post-merge state, 2026-07-06). Its separate apt list still

--- a/src/yars/configuration/ProgramOptions.cpp
+++ b/src/yars/configuration/ProgramOptions.cpp
@@ -184,9 +184,12 @@ void ProgramOptions::__parseProgramOptionsParameters()
   if (_captureFrameRateSet)   __captureFrameRate();
   if (_captureNameSet)        __captureName();
   if (_captureDirSet)         __captureDirectory();
-  if (_framesDirSet)          __captureFramesDirectory();
   if (_captureSet)            __capture();
 #endif // USE_CAPTURE_VIDEO
+  // PNG frame export is independent of the FFmpeg video pipeline
+  // (SdlWindow::__captureImageFrame uses writeContentsToFile) and must
+  // work on builds without USE_CAPTURE_VIDEO — keep it OUTSIDE the guard.
+  if (_framesDirSet)          __captureFramesDirectory();
 
   if (_pauseSet)              __pause();
   if (_realtimeSet)           __realTime();


### PR DESCRIPTION
Root cause: the `--framesDirectory` apply line in `ProgramOptions::__parseProgramOptionsParameters` sat inside `#if USE_CAPTURE_VIDEO` (default OFF), so every default build parsed the option and then silently discarded it — PNG export never armed. PNG frame export uses `RenderTarget::writeContentsToFile`, not the FFmpeg pipeline, and belongs outside that guard.

One line moved out of the guard (plus a comment stating the independence constraint).

## Verification
- 10-iteration GUI run exports valid 800×800 PNGs showing the correct scene: textures, walls, robot, sensor-ray visualization, OSD (visually inspected)
- braitenberg + hexapod 2000-iteration CSV gates bit-exact (option-plumbing only)
- Both CI workflows green
- Restores the project's visual-validation workflow (validate-render skill) and unblocks the Metal plan's acceptance tasks (its Task 0)

Diagnosed via systematic-debugging: instrumented set/read sites proved the setter was never called, which pointed upstream to the preprocessor guard rather than the suspected init-ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)