### PR TITLE
Follow-ups: sanitize job on vendored Bullet; own and free motion states

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -396,6 +396,8 @@ jobs:
     name: ubuntu-22.04 / ASan+UBSan+LSan headless corpus
     runs-on: ubuntu-22.04
     timeout-minutes: 90
+    env:
+      BULLET_INSTALL_PREFIX: ${{ github.workspace }}/ext/bullet/install
     steps:
       - name: Checkout (with submodules)
         uses: actions/checkout@v6
@@ -407,8 +409,41 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential cmake git pkg-config ninja-build \
-            libcli11-dev libbullet-dev libsdl2-dev libxerces-c-dev \
+            libcli11-dev libsdl2-dev libxerces-c-dev \
             libfreetype6-dev libzzip-dev zlib1g-dev
+
+      - name: Cache Bullet 3.25 build
+        id: bullet-cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.BULLET_INSTALL_PREFIX }}
+          key: bullet325-ubuntu22-${{ hashFiles('.gitmodules') }}-v1
+
+      - name: Build Bullet 3.25 from submodule (source-built SIMD Bullet)
+        if: steps.bullet-cache.outputs.cache-hit != 'true'
+        run: |
+          # Exact benchmark configuration (docs/planning/bullet-simd-benchmark.md,
+          # gate: +11.4% on braitenberg 100k headless steps/s). Deliberately
+          # omits Homebrew/apt's extra options (EGL/multithreading/pybullet) —
+          # those are the likely source of the regression this switch fixes;
+          # do not reintroduce them. Linux uses the default SSE path (no
+          # -DBT_USE_NEON, that's arm64/macOS-only and was never passed there
+          # either since bullet3 auto-enables NEON regardless).
+          cmake -S ext/bullet-source -B ext/bullet/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+            -DCMAKE_INSTALL_PREFIX=${BULLET_INSTALL_PREFIX} \
+            -DBUILD_SHARED_LIBS=ON \
+            -DBUILD_BULLET2_DEMOS=OFF \
+            -DBUILD_UNIT_TESTS=OFF \
+            -DBUILD_CPU_DEMOS=OFF \
+            -DBUILD_OPENGL3_DEMOS=OFF \
+            -DBUILD_EXTRAS=OFF \
+            -DBUILD_PYBULLET=OFF \
+            -DUSE_DOUBLE_PRECISION=OFF \
+            -DCMAKE_CXX_FLAGS="-O3"
+          cmake --build ext/bullet/build -j 4
+          cmake --install ext/bullet/build
 
       - name: Configure sanitized build
         run: |
@@ -422,6 +457,8 @@ jobs:
         run: cmake --build build-san -j 4
 
       - name: Run sanitized corpus
+        env:
+          LD_LIBRARY_PATH: ${{ env.BULLET_INSTALL_PREFIX }}/lib
         run: ./scripts/sanitize-corpus.sh build-san
 
       - name: Upload sanitizer logs on failure

--- a/docs/planning/v0.8.7-open-points.md
+++ b/docs/planning/v0.8.7-open-points.md
@@ -227,14 +227,19 @@ Still-warning items, non-fatal:
   of the FFmpeg pipeline; the line now lives outside the guard.
   Visual verification works again (validate-render skill usable).
 
-- **Sanitize job runs against Ubuntu's Bullet 3.06, not the vendored
-  3.25** (post-merge state, 2026-07-06). Its separate apt list still
-  installs `libbullet-dev`; the CMake fallback makes this work, but the
-  corpus exercises a different Bullet than production. Cheap fix when
-  convenient: reuse the shared `bullet325-ubuntu22-*` actions cache +
-  conditional build block in the sanitize job, add
-  `BULLET_INSTALL_PREFIX/lib` to its corpus run, drop `libbullet-dev`
-  from its apt list.
+- ~~Sanitize job runs against Ubuntu's Bullet 3.06, not the vendored
+  3.25~~ **Done 2026-07-07.** The `sanitize` job now carries its own
+  `BULLET_INSTALL_PREFIX` env, the same `actions/cache@v5` restore
+  keyed `bullet325-ubuntu22-${{ hashFiles('.gitmodules') }}-v1` (byte-
+  identical to `build-and-audit`'s, so the two jobs share the cache
+  entry), and the matching conditional
+  `cmake -S ext/bullet-source -B ext/bullet/build ...` build block.
+  `libbullet-dev` dropped from the sanitize job's apt list (only that
+  job's). `sanitize-corpus.sh`'s invocation now exports
+  `LD_LIBRARY_PATH=${BULLET_INSTALL_PREFIX}/lib` (no Ogre entry needed —
+  this build has `YARS_USE_VISUALISATION=OFF`) so the sanitized binary
+  links the vendored `.so`, not the apt one. YAML validated with
+  `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/linux-build.yml'))"`.
 - The `bullet325-*` CI cache keys do not change when the submodule pin
   moves (hashFiles cannot hash a gitlink) — bump the `-v1` suffix
   manually on any future Bullet upgrade.

--- a/docs/planning/v0.8.7-open-points.md
+++ b/docs/planning/v0.8.7-open-points.md
@@ -104,11 +104,51 @@ Tagged at v0.8.7 / commit 87a6d32.
   reduction, consistent with the ~5x call-count drop. The stray
   `#include <iostream>` + `using namespace std;` in `Pose.cpp` (line ~81)
   was also removed in the same commit.
-- Pre-existing leak: the ground body's `groundMotionState`
-  (`src/yars/physics/bullet/Environment.cpp:52`) is never freed —
-  `Object.cpp:25` has the `delete _motionState;` commented out. Audit
-  whether every Object leaks its motion state before fixing (Bullet
-  ownership rules), then fix or file.
+- ~~Pre-existing leak: the ground body's `groundMotionState`~~
+  **Fixed 2026-07-07.** Audit: grepped every `setMotionState`/
+  `getMotionState`/`_motionState` use across `src/yars/physics/bullet/`.
+  Every concrete `Object` subclass (`Box`, `Sphere`, `Capsule`,
+  `Cylinder`, `Ply`, `Composite`) heap-allocates exactly one
+  `MyMotionState`/`MyCompositeMotionState` in its own `init()` and
+  hands it to `setMotionState()` — no sharing between `Object`s, and
+  Bullet's `btRigidBody` never takes ownership of (or deletes) the
+  motion state pointer passed via `btRigidBodyConstructionInfo` (verified:
+  no deleter elsewhere in `ext/bullet-source` construction-info path).
+  So ownership is exclusively per-`Object`, which is why `delete
+  _motionState;` in `~Object()` was safe to re-enable — **except**
+  `Object::_motionState` was never initialized to `nullptr` in the
+  constructor, and `Environment::__init()`'s ground `Object` (built with
+  `std::make_unique<Object>(nullptr)`) never called `setMotionState()`
+  at all, leaving `_motionState` as an uninitialized/garbage pointer.
+  That garbage-pointer risk is almost certainly *why* the delete was
+  commented out in the first place (deleting it would have been UB for
+  the ground object specifically, not the shape/composite objects that
+  do set it).
+
+  Fix (least invasive, raw-pointer ownership already established by the
+  rest of the class — no `unique_ptr` migration needed since
+  `setMotionState`/`_motionState` are used as raw pointers throughout
+  and there's no aliasing to fight):
+  1. `Object::Object()` now initializes `_motionState = NULL;`.
+  2. `Object::~Object()` re-enables `delete _motionState;` (safe now:
+     always either NULL or an exclusively-owned heap object).
+  3. `Object::reset()` now also deletes+nulls the old `_motionState`
+     before calling `init()` — `init()` unconditionally
+     `new`s a fresh motion state via `setMotionState()`, so without this
+     the old one would leak on every reset (a second, previously
+     unnoticed leak, same class of bug).
+  4. `Environment::__init()` now calls `ground->setMotionState(groundMotionState);`
+     right after `setRigidBody`, so the ground's motion state is owned
+     and freed through the same `Object` dtor path as every other
+     object, instead of leaking directly.
+
+  Verified: clean `cmake --build build -j 8`; `braitenberg_logging.xml`
+  and `hexapod_logging.xml` (2000 iters each) diff byte-identical
+  against `xml/reference_logfile.macos-arm64.csv` /
+  `xml/reference_logfile_hexapod.macos-arm64.csv` (empty diff, exit 0);
+  GUI smoke (`timeout 60s ./bin/yars --iterations 500 --xml
+  ../xml/braitenberg.xml`) exits 0 with no crash — a double-free from a
+  bad delete would have shown up here.
 
 ## CI / packaging state
 

--- a/src/yars/physics/bullet/Environment.cpp
+++ b/src/yars/physics/bullet/Environment.cpp
@@ -61,6 +61,7 @@ void Environment::__init()
 
     auto ground = std::make_unique<Object>(nullptr);
     ground->setRigidBody(groundRigidBody);
+    ground->setMotionState(groundMotionState);
     push_back(std::move(ground));
   }
 

--- a/src/yars/physics/bullet/Object.cpp
+++ b/src/yars/physics/bullet/Object.cpp
@@ -9,6 +9,7 @@ Object::Object(DataObject *data)
   _collisionShape = NULL;
   _rigidBody = NULL;
   _softBody = NULL;
+  _motionState = NULL;
   if (_data != NULL)
     _type = _data->type();
   __setInitialValues();
@@ -22,7 +23,7 @@ Object::~Object()
   if (_softBody != NULL)
     delete _softBody;
 
-  // delete _motionState;
+  delete _motionState;
 }
 
 DataObject *Object::data()
@@ -73,6 +74,12 @@ void Object::reset()
   if (_rigidBody != NULL)
   {
     delete _rigidBody;
+  }
+
+  if (_motionState != NULL)
+  {
+    delete _motionState;
+    _motionState = NULL;
   }
 
   init();


### PR DESCRIPTION
Two open-points items:

1. **CI sanitize job now tests against the vendored Bullet 3.25** via the shared `bullet325` cache (was Ubuntu's 3.06) — cache key byte-identical to build-and-audit's so both jobs share one entry; `libbullet-dev` dropped from its apt list.
2. **Motion states owned and freed**: audit confirmed exclusive per-Object ownership (no Bullet-side deleter, no sharing, historic comment-out unexplained by git history). Ctor NULL-init, dtor delete re-enabled, `reset()` frees before `init()` reassigns (second latent leak found during audit), Environment's ground motion state routed into Object ownership.

Verification: both bit-exact CSV gates empty-diff, GUI smoke clean, review independently re-ran all gates and traced every assign/consume path for double-free/dangling windows (none; dtor deletes `_rigidBody` before `_motionState`). Sanitize job green on this branch = live LSan pass with the fix.

Noted for the record (pre-existing, unreachable): `Environment::reset()` is dead code with a latent trap if ever revived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)