### PR TITLE
JSON migration Stage 1: JSON reader — both formats selectable in one binary

### DIFF
--- a/docs/planning/json-migration-notes.md
+++ b/docs/planning/json-migration-notes.md
@@ -380,3 +380,65 @@ File: `src/yars/configuration/YarsConfiguration.cpp`
   soft failures are distinguishable to the caller the same way (`read()`
   returning `false` either way, but only soft failures populate the
   message lists that `YarsConfiguration::__readXmlFiles` prints).
+
+## 8. JSON validation gap (Stage 1 known limitation — needs Stage 1→2 sign-off)
+
+Today, malformed XML is rejected by Xerces XSD validation (§6) **before**
+any `Data*::add(DataParseElement*)` body runs. That validation is what
+makes it safe for 80+ `Data*::add()` implementations to dereference a
+required attribute unchecked — e.g.
+`_physics->setMass(element->attribute(YARS_STRING_KG)->realValue())`
+(`DataBox.cpp:67`) assumes `attribute("kg")` is never `NULL`, because the
+schema already guaranteed `kg` was present on `<mass>` before this code
+ever ran.
+
+`JsonParser` (`src/yars/configuration/json/JsonParser.{h,cpp}`) has **no
+equivalent schema validation**. It catches JSON-structural problems it can
+see — invalid JSON syntax, a missing top-level `rosiml` key, a `#children`
+entry missing its `#tag` field — and reports them cleanly via the
+`errors` out-parameter, matching `YarsXSDSaxParser::errors()`'s contract
+closely enough that `YarsConfiguration::__readXmlFiles` prints and
+`exit(-1)`s the same way for both formats on those failures.
+
+**What it does NOT catch**: a JSON config that is well-formed JSON but
+omits a required XML attribute (e.g. a `<mass>` object with no `"kg"`
+key) reaches the unchanged `Data*::add()` machinery exactly as before,
+and the same unchecked `element->attribute(name)->realValue()` call
+dereferences a `NULL` `DataParseAttribute*` — a segfault, not a clean
+error message.
+
+**Why this wasn't patched at the `DataParseElement::attribute()`
+boundary** (the approach floated in the Stage 1 task brief): `attribute()`
+is used in two shapes throughout the 80+ `Data*::add()` bodies —
+(a) unchecked `attribute(x)->value()` for attributes the schema
+guarantees are present, and (b) `if (attribute(x) != NULL) ...` /
+`element->set(...)` (which itself null-checks) for attributes that are
+**legitimately optional** and fall back to a C++ default when absent
+(confirmed in §6: the schema has no default-injection, defaults live in
+each `Data*` class's own field initializers). `attribute()` has no way to
+distinguish "required, should abort if missing" from "optional, NULL is
+the normal not-provided case" — it's the same function serving both call
+shapes. Making it abort-on-miss unconditionally (e.g. via a virtual
+override in a JSON-specific `DataParseElement` subclass) would fix the
+required-attribute case but break every legitimately-optional attribute
+across the whole `Data*` hierarchy, which is a strictly worse regression
+than the gap it would close. That generic fix needs per-attribute
+required/optional metadata — which is exactly what Stage 4's binding
+tables are for. Patching this properly is deferred to Stage 4, not
+attempted here.
+
+**User-visible statement of the gap (per-brief requirement)**: JSON
+configs are **structurally unvalidated** for Stage 1 — the JSON reader
+will crash (not cleanly error) on a config that is valid JSON but
+violates a schema constraint the XSD would have caught (missing required
+attribute, wrong element nesting the schema would reject, etc.). This is
+acceptable for Stage 1 because JSON configs are currently only produced by
+`XmlToJson` from already-schema-valid XML, so this gap is not reachable
+through the Stage 0→1 pipeline as shipped — it only bites hand-written or
+hand-edited `.json` configs. **The spec's original validation promise
+(reject malformed config input cleanly) is only fully restored once ALL
+`Data*` families have Stage 4 binding tables with required/optional
+attribute metadata.** Explicit sign-off on this gap is needed at the
+Stage 1 → Stage 2 boundary before JSON configs are treated as a
+first-class, hand-editable format rather than a converter-only
+intermediate.

--- a/docs/planning/json-migration-notes.md
+++ b/docs/planning/json-migration-notes.md
@@ -1,0 +1,382 @@
+# JSON Stage 1 — XML parser event-stream contract (characterization notes)
+
+Read-only characterization of the existing XSD/SAX parsing pipeline. All
+claims below are cited by `file:line` against the working tree at
+`/Volumes/Eregion/projects/yars-json`. A JSON-driven replayer must reproduce
+this event contract exactly (same DataParseElement objects, same order, same
+lifetime rules) so that all `Data*::add(DataParseElement*)` state machines
+(80+ factory/data classes) work completely unchanged.
+
+## 1. How opening/closing `DataParseElement` events are constructed
+
+File: `src/yars/configuration/xsd/parser/YarsXSDSaxHandler.cpp`
+
+- `startElement(uri, localname, qname, attrs)` (handler signature at
+  `YarsXSDSaxHandler.h:27-31`; body at `YarsXSDSaxHandler.cpp:16-49`):
+  - Tag name source is **`localname`**, not `qname` — see
+    `YarsXSDSaxHandler.cpp:22` (`message = XMLString::transcode(localname)`)
+    and `:27` (`element->setName(message)`). `qname` and `uri` are
+    transcoded (`:24-25`) but never used for the element name — they are
+    transcoded only so the corresponding `XMLString::release` calls balance;
+    functionally dead values (`m_uri`, `m_localname`, `m_qname` are computed
+    but never read except to free them, `:44-47`).
+  - Namespaces ARE turned on in the reader
+    (`XMLUni::fgSAX2CoreNameSpaces = true`,
+    `YarsXSDSaxParser.cpp:51`/`:177`), but namespace **prefixes** are off
+    (`fgSAX2CoreNameSpacePrefixes = false`, `YarsXSDSaxParser.cpp:55`/`:181`).
+    Since the schema and all XML documents in this codebase are
+    non-namespaced, `uri` is effectively always empty; only `localname`
+    matters. A JSON replayer only needs a plain tag-name string — no
+    namespace/prefix handling required.
+  - Opening element construction: `new DataParseElement(YARS_DATA_PARSE_ELEMENT_TYPE_OPENING)`
+    (`YarsXSDSaxHandler.cpp:26`), type constant `2001`
+    (`DataParseElement.h:10`).
+  - Attributes are attached only if `attrs.getLength() > 0`
+    (`YarsXSDSaxHandler.cpp:29`). For each attribute a `DataParseAttribute`
+    is created (`:33`) with:
+    - name = `attrs.getQName(i)` transcoded to `std::string`
+      (`YarsXSDSaxHandler.cpp:34,39`) — note this is the **qname** for
+      attributes (not localname as for elements). Since there's no
+      namespace prefixing in practice, qname == localname for attributes
+      too, in this codebase.
+    - value = `attrs.getValue(i)` transcoded to `std::string`
+      (`:38,40`).
+    - `attrs.getURI(i)` and `attrs.getLocalName(i)` and `attrs.getType(i)`
+      are transcoded (`:35-37`) but **never used** — dead code, same
+      pattern as the element-name dead transcodes above.
+    - Attribute is appended via `element->add(a)` →
+      `push_back(attribute)` (`DataParseElement.cpp:32-35`); `DataParseElement`
+      itself *is* a `std::vector<DataParseAttribute*>`
+      (`DataParseElement.h:20`).
+    - All attribute values are stored purely as strings
+      (`DataParseAttribute::_value`, `DataParseAttribute.h:91`); typed
+      accessors (`intValue()`, `realValue()`, `boolValue()`,
+      `unsignedlongValue()`) do lazy conversion via `atoi`/`atof`/`"true"`
+      comparison at read time with **no error handling**
+      (`DataParseAttribute.cpp:37-55`). A JSON reader must therefore also
+      produce all attribute values as strings (or something that supports
+      identical stringly-typed conversions) if it wants to reuse
+      `DataParseElement::set(...)` (`DataParseElement.cpp:73-111`), which
+      calls these same converters.
+  - Finished opening element is handed to the spec:
+    `_spec->add(element)` (`YarsXSDSaxHandler.cpp:48`) — see §2.
+  - There is **no separate "closing" constructor** — the *type* is what
+    distinguishes opening vs. closing (`YARS_DATA_PARSE_ELEMENT_TYPE_OPENING`
+    = 2001 vs `YARS_DATA_PARSE_ELEMENT_TYPE_CLOSING` = 2002,
+    `DataParseElement.h:10-11`). Both are the same class, constructed with a
+    different `int type` ctor arg (`DataParseElement.h:32`,
+    `DataParseElement.cpp:3-7`).
+
+- `endElement(uri, localname, qname)` (`YarsXSDSaxHandler.h:33-36`; body
+  `YarsXSDSaxHandler.cpp:51-62`):
+  - Only `localname` is used (`:53,56`); `uri`/`qname` params are unnamed in
+    the signature (`YarsXSDSaxHandler.h:34,36` — the `uri` and `qname`
+    parameters are anonymous, confirming they're intentionally unused).
+  - Closing element: `new DataParseElement(YARS_DATA_PARSE_ELEMENT_TYPE_CLOSING)`
+    (`:57`), name set from `localname` (`:58`), **no attributes are ever
+    attached to a closing element** — `endElement` has no `Attributes`
+    parameter to draw from, and nothing calls `add()` on it.
+
+## 2. Dispatch: `_spec->add(element)` and per-class matching
+
+- `_spec` is a `DataRobotSimulationDescription*`
+  (`YarsXSDSaxHandler.h:67`), set once per document in `startDocument()`:
+  `_spec = Data::instance()->newSpecification();` (`YarsXSDSaxHandler.cpp:66`,
+  declared `YarsXSDSaxHandler.h:38`).
+- `DataRobotSimulationDescription::add(DataParseElement*)`
+  (`DataRobotSimulationDescription.cpp:112-123`):
+  ```
+  if(current == NULL) current = this;
+  if(current == this) __getChild(element);
+  else current->add(element);
+  ```
+  `current` is a `DataNode*` member (inherited; set in the ctor to `this`,
+  `DataRobotSimulationDescription.cpp:36`). This is a simple **tree-walk
+  dispatcher**: every event is routed to whichever `DataNode` subtree is
+  "current" at that moment, and every intermediate node's own `add()`
+  recurses further down until reaching whichever concrete `Data*` class
+  actually owns the currently-open tag. There is no stack structure
+  visible at this call site — instead each concrete class flips `current`
+  to itself on its own opening tag and flips it back to `parent` on its own
+  closing tag (see `DataBox::add`, `DataBox.cpp:42-45`: `if
+  (element->closing(YARS_STRING_OBJECT_BOX)) current = parent;`). This
+  means the "stack" is implicit and distributed: each node keeps a
+  `parent` pointer and reassigns the ancestor-shared `current` variable
+  as elements open/close. A JSON replayer must feed events in the same
+  strict open/close nesting order the XML SAX stream would produce, because
+  this dispatch mechanism has no lookahead or backtracking — it purely
+  reacts to the sequential event stream.
+- Root-level element matching (`__getChild`,
+  `DataRobotSimulationDescription.cpp:125-252`) is a **chain of
+  `if(element->opening(TAG))` checks** — plain string compares, no dispatch
+  table, no `switch`. Order in the file is the only precedence.
+- `DataParseElement::opening(string name)` /
+  `closing(string name)` (`DataParseElement.cpp:53-71`):
+  ```
+  bool opening(string name) { return _name == name && _type == OPENING; }
+  bool closing(string name) { return _name == name && _type == CLOSING; }
+  ```
+  Exact, case-sensitive `std::string::operator==` comparison. There is a
+  `char*` overload too (`opening(char*)`/`closing(char*)`,
+  `DataParseElement.cpp:58-61,68-71`) that just wraps the string in
+  `std::string(name)` — used everywhere via `YARS_STRING_*` `(char*)"..."`
+  macros (e.g. `DataBox.cpp:11-23`). No case-folding, no trimming, no
+  namespace-qualification — the tag name is compared literally byte-for-byte
+  against the macro string literal.
+- Representative leaf class `DataBox::add(DataParseElement*)`
+  (`DataBox.cpp:40-86`) follows the identical pattern: a flat sequence of
+  `if(element->opening(TAG))` / `if(element->closing(TAG))` checks, each
+  either mutating local state directly (`element->set(...)`,
+  `element->attribute(...)->value()`) or constructing a child `Data*`
+  object and reassigning `current` to it (e.g. opening `physics` sets
+  `current = _physics` at `DataBox.cpp:60-64`; opening a mesh-visualisation
+  tag allocates a new `DataMeshVisualisation`, appends it, and reassigns
+  `current` to it, `DataBox.cpp:79-85`). Closing `box` resets
+  `current = parent` (`DataBox.cpp:42-45`) — note this specific `if` has
+  **no `return`/`else`** guarding it from the rest of the function; the
+  closing check runs first and other `opening(...)` checks below still
+  execute on the same event object even after `current` has already been
+  reset (harmless here since a closing-box element never simultaneously
+  matches any of the opening checks below it, but it shows the dispatch
+  style is "run every check every time," not "match once and stop").
+
+## 3. Lifetime rules
+
+- **Opening elements**: allocated with `new` in `startElement`
+  (`YarsXSDSaxHandler.cpp:26`), handed to `_spec->add(element)`
+  (`:48`), and **never explicitly deleted by the handler**. Nothing in
+  `YarsXSDSaxHandler.cpp` frees an opening `DataParseElement`. Whether any
+  downstream `Data*::add()` deletes it was not found in the classes read
+  for this task (`DataRobotSimulationDescription::add`,
+  `DataBox::add` — neither deletes the `element` pointer they're given).
+  **Conclusion: opening `DataParseElement` instances are leaked** for the
+  lifetime characterization purposes (confirmed no matching `delete
+  element` anywhere in the read files). A JSON replayer that constructs
+  its own `DataParseElement` objects to feed into the *unchanged*
+  `Data*::add()` machinery should preserve this leak rather than
+  "fixing" it, to avoid double-free/use-after-free if any `Data*::add()`
+  elsewhere in the tree (not read here) retains the pointer past the call.
+- **Closing elements**: allocated, immediately passed to `_spec->add(element)`,
+  then **immediately `delete`d in the same function**, before
+  `XMLString::release`:
+  ```cpp
+  DataParseElement *element = new DataParseElement(YARS_DATA_PARSE_ELEMENT_TYPE_CLOSING);
+  element->setName(message);
+  _spec->add(element);
+  delete element;                 // YarsXSDSaxHandler.cpp:60
+  XMLString::release(&message);
+  ```
+  (`YarsXSDSaxHandler.cpp:57-61`). This **confirms the known fact stated in
+  the task**: `endElement` does add-then-delete synchronously, so every
+  `Data*::add()` invoked for a closing tag must finish all its own work
+  (reading `element->name()`, checking `closing(TAG)`, reassigning
+  `current`) synchronously within the `_spec->add(element)` call — nothing
+  downstream may store the closing element pointer and use it later. A
+  JSON replayer must likewise delete each closing `DataParseElement`
+  synchronously right after the `add()` call returns (or otherwise avoid
+  handing out a pointer that outlives that single dispatch), matching
+  exactly this pattern.
+- `DataParseElement::~DataParseElement()` (`DataParseElement.cpp:9-15`)
+  deletes every attribute it owns (`for i in size(): delete at(i)`) — so
+  deleting a closing element is cheap (it never has attributes, per §1) but
+  deleting an opening element (if anyone ever does) would free its
+  attributes too.
+
+## 4. Events beyond open/close
+
+`YarsXSDSaxHandler` overrides (`YarsXSDSaxHandler.h:27-43`):
+`startElement`, `endElement`, `startDocument`, `endDocument`, `error`,
+`fatalError`, `warning`. It extends `xercesc::DefaultHandler`
+(`YarsXSDSaxHandler.h:22`), which also has a virtual `characters(...)`
+callback — **`YarsXSDSaxHandler` does NOT override `characters()`**, so
+text content between tags is silently discarded via the base-class no-op
+implementation. **Confirmed: no `characters()` handling exists** — grep
+for `characters` in `YarsXSDSaxHandler.{h,cpp}` returns nothing.
+This means the XML format here is purely attribute-driven; there is no
+inline text-node payload for any element in the schema that the parser
+actually looks at. A JSON replayer does not need a "characters" event
+equivalent.
+
+- `startDocument()` (`YarsXSDSaxHandler.cpp:64-67`) is the **only place**
+  `_spec` gets initialized — `_spec = Data::instance()->newSpecification();`.
+  This must run exactly once per document, before the first `startElement`.
+- `endDocument()` (`YarsXSDSaxHandler.cpp:69-72`) is a no-op ("noting" —
+  literal comment typo in the source).
+- `error`/`fatalError`/`warning` (`YarsXSDSaxHandler.cpp:74-102`) push
+  formatted strings (`"Error: <msg> at line: <n>"` etc.) into
+  `_errors`/`_fatals`/`_warnings` vectors — **they do not mutate `_spec`
+  or throw**; they just accumulate messages for the caller
+  (`YarsXSDSaxParser::read`) to inspect after `parser->parse(...)` returns
+  (see §6). Schema-validation errors surface via `error()`/`fatalError()`,
+  not via C++ exceptions, in the common case (exceptions are also caught
+  separately for XML well-formedness failures — see §6).
+
+## 5. Where the XML path is chosen in `YarsConfiguration`
+
+File: `src/yars/configuration/YarsConfiguration.cpp`
+
+- `YarsConfiguration::__readXmlFiles()` (`:216-240`) is the single call
+  site that instantiates the SAX parser:
+  ```cpp
+  Data::instance()->clear();
+  string xml = getXml();                                   // :219
+  auto parser = std::make_unique<YarsXSDSaxParser>();       // :221
+  parser->read(xml);                                        // :223
+  if (parser->errors() > 0) { ... exit(-1); }               // :224-233
+  ```
+  **This is the exact insertion point for a `.json` branch**: after
+  `string xml = getXml();` (`:219`), branch on file extension (or content)
+  and either call `parser->read(xml)` (existing XML path, `:221-223`) or a
+  new JSON-driving equivalent that ultimately performs the same sequence
+  of `_spec->add(element)` calls that `YarsXSDSaxHandler` performs today.
+  `getXml()` (accessor declared via `ConfigurationContainer`, not read in
+  this pass) returns the path string exactly as given on the command line
+  — including the literal `"-"` sentinel for stdin.
+  - The parser is handed a **file path string** — `parser->read(filename)`
+    signature (`YarsXSDSaxParser.h:28`), passed straight to
+    `parser->parse(filename.c_str())` (`YarsXSDSaxParser.cpp:84`) for the
+    Xerces `SAX2XMLReader`, which opens/reads the file itself. Nothing in
+    YARS pre-reads the file into a buffer for the normal (file) path.
+  - The **stdin `"-"` mode**: `YarsXSDSaxParser::read` special-cases
+    `filename == "-"` (`YarsXSDSaxParser.cpp:77-81`):
+    ```cpp
+    if(filename == "-") { StdInInputSource src; parser->parse(src); }
+    else                { parser->parse(filename.c_str()); }
+    ```
+    A JSON replayer needs the equivalent: if the path is `"-"`, read JSON
+    from stdin instead of opening a file.
+  - `YarsConfiguration::__validateXmlPath()` (`:286-...`, reads
+    `string xml = getXml()` at `:288`) validates existence via
+    `_directories->doesFileExist(xml)` **only when `xml != "-"`**
+    (`:295-301`) — i.e. stdin mode deliberately bypasses the file-exists
+    check. Any JSON path-selection logic inserted before/alongside this
+    must preserve the same `"-"` bypass for a `.json` stdin mode if that's
+    desired, and should be inserted consistently in both
+    `__validateXmlPath()` and `__readXmlFiles()` (there are two independent
+    `string xml = getXml();` call sites: `:219` and `:288`).
+
+## 6. Validation side effects
+
+- Schema validation is Xerces SAX2 core validation
+  (`XMLUni::fgSAX2CoreValidation = true`, `YarsXSDSaxParser.cpp:48`/`:175`),
+  loaded from an in-memory generated XSD (`YarsXSDGenerator`, `:37-41` /
+  `:164-170`), not a static file. Validation is purely rejecting: nowhere in
+  `YarsXSDSaxHandler`/`YarsXSDSaxParser` is there any code that injects a
+  schema default value into a `DataParseElement`/`DataParseAttribute`
+  when an attribute is omitted from the XML — the schema is used only to
+  flag structural/type errors via `error()`/`fatalError()`/`warning()`
+  callbacks (confirmed: those three overrides only push message strings,
+  `YarsXSDSaxHandler.cpp:74-102`; no `_spec` or `element` mutation
+  anywhere in them). Any "default when absent" behavior in this codebase
+  happens later, inside individual `Data*` classes' own C++ default field
+  initializers — not in the parser layer.
+- Two failure channels, both surfaced in `YarsXSDSaxParser::read`
+  (`YarsXSDSaxParser.cpp:23-145`):
+  1. **C++ exceptions** (`XMLException`, `SAXParseException`) thrown out of
+     `parser->parse(...)` (well-formedness failures, I/O errors) — caught
+     at `:87-98` and `:99-110`; on catch, the message is printed to
+     `cout`, the parser/handler are cleaned up, `XMLPlatformUtils::Terminate()`
+     is attempted, and `read()` returns `false` immediately (accumulated
+     `_errors`/`_warnings`/`_fatals` from the handler are **not** copied
+     back to the `YarsXSDSaxParser` members in this exception path — they
+     are only copied at `:117-119`, which is skipped when an exception is
+     caught early).
+  2. **Non-throwing schema validation errors**, accumulated in the handler
+     via `error()`/`fatalError()`/`warning()` and copied to the parser's own
+     `_errors`/`_fatals`/`_warnings` at `YarsXSDSaxParser.cpp:117-119` after
+     `parser->parse()` returns normally. `read()` returns `false` iff
+     `_fatals.size() > 0 || _errors.size() > 0` (`:140-143`) — warnings
+     alone do not fail the parse.
+  - Caller-side (`YarsConfiguration::__readXmlFiles`,
+    `YarsConfiguration.cpp:224-233`): checks `parser->errors() > 0`
+    (`YarsXSDSaxParser::errors()` = `_fatals.size() + _errors.size()`,
+    `YarsXSDSaxParser.cpp:316-319`), prints all warnings/errors/fatals, and
+    calls `exit(-1)` (`YarsConfiguration.cpp:232`) — hard process exit, not
+    an exception bubbling further up.
+  - A JSON reader must fail comparably: it should be capable of (a)
+    throwing/failing hard on malformed JSON (structural parse failure,
+    analogous to the `XMLException`/`SAXParseException` catch blocks) and
+    (b) accumulating semantic/schema-shaped validation errors into
+    equivalent `_errors`/`_fatals`/`_warnings` lists so the exact same
+    `if (parser->errors() > 0) { ...; exit(-1); }` block in
+    `YarsConfiguration::__readXmlFiles` keeps working unmodified (or with
+    minimal changes) against the new reader.
+  - Additionally, `DataRobotSimulationDescription::__getChild` itself calls
+    `exit(-1)` directly for XML **version** mismatches on the root
+    `rosiml` opening tag (`DataRobotSimulationDescription.cpp:184-195`,
+    `:196-209`) — this is a third, semantically separate failure path that
+    is *not* routed through the SAX error handler at all; it fires the
+    moment the opening `rosiml` element (with its `version` attribute) is
+    dispatched, i.e. mid-stream, not at end-of-parse. A JSON replayer must
+    still emit an opening `rosiml`-equivalent element carrying a `version`
+    attribute, in the same position (very first element), for this check
+    to keep working unchanged.
+
+## 7. Surprises / gotchas for the implementer
+
+- **Root element name is `rosiml`**, not e.g. `yars` or `simulation` —
+  macro `YARS_STRING_ROSIML = "rosiml"` (`DataRobotSimulationDescription.h:27`),
+  used both for XSD root generation
+  (`DataRobotSimulationDescription.cpp:344`, `_root = new
+  XsdSequence(YARS_STRING_ROSIML)`) and for the version-check dispatch in
+  `__getChild` (`:176`). The generated schema file is even named
+  `rosiml.xsd` (`YarsConfiguration.cpp:166`). Any JSON equivalent likely
+  wants a top-level `"rosiml"`-named object/wrapper (or at minimum, the
+  replayer must synthesize a `DataParseElement` opening event named
+  `"rosiml"` with a `version` attribute as the very first event, and a
+  matching closing `"rosiml"` event as the very last).
+- **Tag-name matching is by `localname`, not `qname`**, and is a plain
+  case-sensitive `std::string ==`. No trimming/normalization occurs
+  anywhere in the read files. JSON keys must match these XML tag-name
+  strings byte-for-byte (same macros, e.g. `"box"`, `"dimension"`,
+  `"pose"`, `"texture"`, `"first"`/`"second"`/... for the 6-texture box
+  faces, `DataBox.cpp:14-19`) if the replayer wants to drive the unchanged
+  `Data*::add()` code.
+- **All attribute values are strings end-to-end.** Even numeric/boolean
+  attributes are stored as `std::string` in `DataParseAttribute::_value`
+  and only converted on demand via `atoi`/`atof`/`== "true"` with zero
+  error handling (`DataParseAttribute.cpp:37-55`). A JSON reader that
+  hands numeric/boolean JSON values straight through as C++ `double`/`bool`
+  would break `DataParseElement::set(...)` unless it first stringifies
+  them (e.g. JSON number `3.5` → `DataParseAttribute::setValue("3.5")`)
+  exactly as the XML attribute string would have looked, matching what
+  `atof`/`atoi` expect (locale-independent `atof`, no thousands separators,
+  `"true"`/anything-else for bool).
+- **No stack — a single mutable `current` pointer** threads through the
+  whole `DataNode` hierarchy (`DataRobotSimulationDescription.cpp:36`,
+  `:112-123`; `DataBox.cpp:42-45,60-64,79-85`). This means the replayer
+  must emit strictly well-nested open/close pairs in depth-first order —
+  exactly like a SAX stream — because there's no tolerance for
+  out-of-order or overlapping events; the mechanism has no way to detect
+  or recover from malformed nesting (it will silently misattribute
+  elements to the wrong `current` node instead of erroring).
+- **Dead/no-op transcodes are pervasive**: `uri`, `qname`, `m_localname`
+  local variables in `startElement` (`YarsXSDSaxHandler.cpp:23-25`), and
+  `a_uri`/`a_local`/`a_type` per-attribute (`:35-37`) are computed and
+  released but never read. Don't assume every transcoded field is
+  semantically meaningful — check actual usage.
+- **Opening `DataParseElement`s appear to leak** (see §3) — this is
+  existing behavior, not something Stage 1 should "fix" as a side effect;
+  changing it could change memory/ownership assumptions in code not
+  audited here (all 80+ `Data*::add()` implementations were not
+  individually checked for whether any of them takes ownership/deletes the
+  opening element it's handed).
+- **`DataBox::add`'s closing-tag branch has no `return`** (`DataBox.cpp:42-45`),
+  unlike most other closing-tag handling seen in
+  `DataRobotSimulationDescription::__getChild` (some branches `return`
+  after handling an opening tag, e.g. `:132,140,156,166,173,222`; others,
+  like `traces`/`logging`/`rosiml`-closing, fall through to the bottom of
+  the function without returning, `:230,237,251`). This inconsistency is
+  pre-existing in the XML-driven code; a JSON replay implementer should not
+  be surprised if some classes exhibit near-miss double-matching for a
+  single event — but since dispatch is by exact `(type, name)` match, this
+  is harmless in practice (a "closing box" event can't also be "opening
+  pose", etc.).
+- **`errors` from an early-thrown exception during `parser->parse()` are
+  not copied back to `_errors`/`_fatals`/`_warnings`** (see §6) — only the
+  normal-return path copies handler state to the parser object
+  (`YarsXSDSaxParser.cpp:117-119` / `:240-242`). If a JSON reader wants
+  parity, ensure both exception-style hard failures *and* validation-style
+  soft failures are distinguishable to the caller the same way (`read()`
+  returning `false` either way, but only soft failures populate the
+  message lists that `YarsConfiguration::__readXmlFiles` prints).

--- a/docs/planning/json-migration-notes.md
+++ b/docs/planning/json-migration-notes.md
@@ -435,7 +435,11 @@ attribute, wrong element nesting the schema would reject, etc.). This is
 acceptable for Stage 1 because JSON configs are currently only produced by
 `XmlToJson` from already-schema-valid XML, so this gap is not reachable
 through the Stage 0→1 pipeline as shipped — it only bites hand-written or
-hand-edited `.json` configs. **The spec's original validation promise
+hand-edited `.json` configs. (Review addendum 2026-07-07: one indirect
+path exists — `XmlToJson` parses with validation disabled (`Val_Never`),
+so converting a well-formed but schema-INVALID .xml yields a .json that
+crashes at runtime where the .xml itself would have been rejected by
+XSD. Convert only known-valid configs until Stage 4 lands.) **The spec's original validation promise
 (reject malformed config input cleanly) is only fully restored once ALL
 `Data*` families have Stage 4 binding tables with required/optional
 attribute metadata.** Explicit sign-off on this gap is needed at the

--- a/scripts/convert-corpus.sh
+++ b/scripts/convert-corpus.sh
@@ -3,12 +3,16 @@
 # Runs `yars --convert` over every XML config in the corpus (xml/*.xml and
 # xml/joints/*.xml) and reports PASS/FAIL per file.
 #
-# Some corpus files are expected to legitimately fail conversion, per the
-# XmlToJson converter's loud-failure design (see
-# src/yars/configuration/json/XmlToJson.h): non-whitespace element text
-# content, or non-contiguous same-tag siblings under a parent. Those files
-# are listed in EXPECTED_FAIL below, each with a comment citing the specific
-# element responsible.
+# Only genuine converter bugs are expected to fail conversion now. Prior to
+# Stage 1's #children amendment (see src/yars/configuration/json/XmlToJson.h
+# and docs/planning/json-migration-notes.md), non-contiguous same-tag
+# siblings under a parent (e.g. hexaboard.xml/hexapod_*.xml's interleaved
+# <deflection> sensors, muscle_tcpip.xml's interleaved <domain>/<mapping>)
+# made the converter throw loudly. XmlToJson now represents those parents'
+# children as an ordered "#children" array instead, so all corpus files are
+# expected to convert. EXPECTED_FAIL stays empty; only add an entry after
+# inspecting a NEW failure and confirming it is a genuine unhandled case
+# (e.g. non-whitespace element text content), not a converter regression.
 #
 # Usage: ./scripts/convert-corpus.sh   (run from repo root)
 
@@ -24,27 +28,7 @@ if [[ ! -x "$YARS_BIN" ]]; then
   exit 1
 fi
 
-# Files that are expected to fail --convert. Empty initially; add entries
-# here only after inspecting the failure and confirming it is a genuine
-# interleaved-siblings or text-content case, not a converter bug.
-EXPECTED_FAIL=(
-  # <sensors> mixes deflection/deflection/binaryContact groups repeatedly
-  # (e.g. lines ~513-572): <deflection> siblings are non-contiguous.
-  "xml/hexaboard.xml"
-  # same <sensors> interleaving pattern as hexaboard.xml.
-  "xml/hexapod_logging.xml"
-  # same <sensors> interleaving pattern as hexaboard.xml.
-  "xml/hexapod_mpi.xml"
-  # <actuators> has <generic> blocks (lines ~294-412), then <hinge> blocks
-  # (~414-531), then more <generic> blocks (~533+): <generic> siblings are
-  # non-contiguous.
-  "xml/hexapod_ralf.xml"
-  # same <sensors>/<deflection> interleaving pattern as hexaboard.xml.
-  "xml/hexapod_shadow_test.xml"
-  # <muscle> alternates <domain>/<mapping> pairs repeatedly (lines ~123-136):
-  # <domain> (and <mapping>) siblings are non-contiguous.
-  "xml/muscle_tcpip.xml"
-)
+EXPECTED_FAIL=()
 
 is_expected_fail() {
   local f="$1"

--- a/scripts/json-roundtrip-check.sh
+++ b/scripts/json-roundtrip-check.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#
+# Stage 1 acceptance check (JSON Stage 1 brief, Step 4): for each config in
+# the CI-runnable corpus (the same 13 configs sanitize-corpus.sh exercises,
+# mirroring the STANDALONE/CFG2LIB arrays in .github/workflows/linux-build.yml),
+# convert XML -> JSON, run both from the .xml and from the converted .json,
+# and compare:
+#   - braitenberg_logging / hexapod_logging (the two logging configs):
+#     bit-exact CSV diff.
+#   - everything else: exit code + final console line.
+#
+# Usage: scripts/json-roundtrip-check.sh <build-dir>   (default: build)
+
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${1:-$ROOT/build}"
+# Resolve to an absolute path: run_one() cd's into a scratch directory
+# before invoking $YARS_BIN, so a relative BUILD_DIR (e.g. the default
+# caller-friendly "build") would otherwise silently fail to resolve there.
+BUILD_DIR="$(cd "$BUILD_DIR" && pwd)"
+YARS_BIN="$BUILD_DIR/bin/yars"
+
+if [[ ! -x "$YARS_BIN" ]]; then
+  echo "Error: $YARS_BIN not found or not executable. Build first." >&2
+  exit 1
+fi
+
+# Standalone configs (no controller library needed).
+STANDALONE=(
+  xml/braitenberg_nocontroller.xml
+  xml/falling_objects.xml
+  xml/test_capture.xml
+  xml/hexapod_logging.xml
+)
+# Controller-based configs: config -> lib name (mirrors sanitize-corpus.sh /
+# linux-build.yml).
+CONFIGS=(
+  "xml/braitenberg.xml:YarsControllerBraitenberg2b"
+  "xml/braitenberg_noise.xml:YarsControllerBraitenberg2b"
+  "xml/braitenberg_logging.xml:YarsControllerBraitenberg3b"
+  "xml/braitenberg_light_source.xml:YarsControllerBraitenberg2b"
+  "xml/braitenberg_trace_projection.xml:YarsControllerBraitenberg2b"
+  "xml/braitenberg_zoo.xml:YarsControllerBraitenberg2a"
+  "xml/muscle.xml:YarsControllerSquareWave"
+  "xml/joints/generic_angular.xml:YarsControllerSine"
+  "xml/joints/generic_force.xml:YarsControllerSine"
+)
+
+# The two logging configs get a bit-exact CSV diff; everything else gets
+# exit-code + final-console-line comparison.
+is_logging_config() {
+  case "$1" in
+    xml/braitenberg_logging.xml|xml/hexapod_logging.xml) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+FAILED=0
+TOTAL=0
+PASSED=0
+
+run_one() {
+  local cfg="$1"
+  local name
+  name="$(basename "$cfg" .xml)"
+  TOTAL=$((TOTAL + 1))
+
+  local xmlpath="$ROOT/$cfg"
+  local jsonpath="${xmlpath%.xml}.json"
+
+  # 1. Convert.
+  if ! timeout 30s "$YARS_BIN" --convert "$xmlpath" >"$WORKDIR/${name}-convert.log" 2>&1; then
+    echo "FAIL $cfg (conversion failed, see $WORKDIR/${name}-convert.log)"
+    sed 's/^/  /' "$WORKDIR/${name}-convert.log"
+    FAILED=1
+    return
+  fi
+  if [[ ! -f "$jsonpath" ]]; then
+    echo "FAIL $cfg (conversion did not produce $jsonpath)"
+    FAILED=1
+    return
+  fi
+
+  # 2/3. Run 500 iters from each format. Controller libraries are located
+  # via a path relative to CWD (confirmed: running from outside $BUILD_DIR
+  # fails with "Controller '...' not found"), so both runs must execute
+  # with $BUILD_DIR as CWD, exactly like sanitize-corpus.sh does. CSV
+  # logging output also lands in CWD, so any newly-created *.csv is moved
+  # out to a per-run scratch dir immediately after each run (sequential,
+  # not parallel, so there's no cross-run collision).
+  local xmldir="$WORKDIR/${name}-xml"
+  local jsondir="$WORKDIR/${name}-json"
+  mkdir -p "$xmldir" "$jsondir"
+
+  local before_csvs after_csvs new_csv
+  before_csvs="$(ls "$BUILD_DIR"/*.csv 2>/dev/null || true)"
+  ( cd "$BUILD_DIR" && timeout 120s "$YARS_BIN" --iterations 500 --nogui --xml "$xmlpath" \
+      >"$WORKDIR/${name}-xml.log" 2>&1 )
+  local xml_rc=$?
+  after_csvs="$(ls "$BUILD_DIR"/*.csv 2>/dev/null || true)"
+  for f in $after_csvs; do
+    if ! grep -qxF "$f" <<<"$before_csvs"; then
+      mv "$f" "$xmldir/"
+    fi
+  done
+
+  before_csvs="$(ls "$BUILD_DIR"/*.csv 2>/dev/null || true)"
+  ( cd "$BUILD_DIR" && timeout 120s "$YARS_BIN" --iterations 500 --nogui --xml "$jsonpath" \
+      >"$WORKDIR/${name}-json.log" 2>&1 )
+  local json_rc=$?
+  after_csvs="$(ls "$BUILD_DIR"/*.csv 2>/dev/null || true)"
+  for f in $after_csvs; do
+    if ! grep -qxF "$f" <<<"$before_csvs"; then
+      mv "$f" "$jsondir/"
+    fi
+  done
+
+  if [[ $xml_rc -ne $json_rc ]]; then
+    echo "FAIL $cfg (exit code mismatch: xml=$xml_rc json=$json_rc)"
+    FAILED=1
+    return
+  fi
+
+  if is_logging_config "$cfg"; then
+    local xml_csv json_csv
+    xml_csv=$(ls "$xmldir"/*.csv 2>/dev/null | head -1)
+    json_csv=$(ls "$jsondir"/*.csv 2>/dev/null | head -1)
+    if [[ -z "$xml_csv" || -z "$json_csv" ]]; then
+      echo "FAIL $cfg (expected CSV logging output, xml_csv='$xml_csv' json_csv='$json_csv')"
+      FAILED=1
+      return
+    fi
+    if ! diff -q "$xml_csv" "$json_csv" >/dev/null; then
+      echo "FAIL $cfg (CSV mismatch: $xml_csv vs $json_csv)"
+      diff "$xml_csv" "$json_csv" | head -20
+      FAILED=1
+      return
+    fi
+    echo "PASS $cfg (exit=$xml_rc, CSV bit-exact)"
+  else
+    local xml_last json_last
+    xml_last=$(tail -1 "$WORKDIR/${name}-xml.log")
+    json_last=$(tail -1 "$WORKDIR/${name}-json.log")
+    if [[ "$xml_last" != "$json_last" ]]; then
+      echo "FAIL $cfg (final console line mismatch)"
+      echo "  xml : $xml_last"
+      echo "  json: $json_last"
+      FAILED=1
+      return
+    fi
+    echo "PASS $cfg (exit=$xml_rc, final line matches)"
+  fi
+  PASSED=$((PASSED + 1))
+  rm -f "$jsonpath"
+}
+
+for cfg in "${STANDALONE[@]}"; do
+  run_one "$cfg"
+done
+for entry in "${CONFIGS[@]}"; do
+  cfg="${entry%%:*}"
+  lib="${entry##*:}"
+  if ! ls "$BUILD_DIR"/lib/lib${lib}.* >/dev/null 2>&1; then
+    echo "FAIL $cfg (lib${lib} missing from $BUILD_DIR/lib — build first)"
+    FAILED=1
+    TOTAL=$((TOTAL + 1))
+    continue
+  fi
+  run_one "$cfg"
+done
+
+echo ""
+echo "Round-trip: $PASSED/$TOTAL passed"
+
+exit $FAILED

--- a/src/yars/configuration/CMakeLists.txt
+++ b/src/yars/configuration/CMakeLists.txt
@@ -97,6 +97,7 @@ set(CFG_SRC YarsConfiguration.cpp
             data/DataSoftBodyParameters.cpp
 
             json/XmlToJson.cpp
+            json/JsonParser.cpp
 
             xsd/generator/YarsXSDGenerator.cpp
             xsd/generator/XSDString.cpp

--- a/src/yars/configuration/YarsConfiguration.cpp
+++ b/src/yars/configuration/YarsConfiguration.cpp
@@ -11,6 +11,7 @@
 #include <yars/configuration/xsd/graphviz/XsdGraphvizExporter.h>
 #include <yars/configuration/xsd/generator/YarsXSDGenerator.h>
 #include <yars/configuration/data/XmlChangeLog.h>
+#include <yars/configuration/json/JsonParser.h>
 
 #include <yars/defines/program_options.h>
 #include <yars/defines/keyboard_shortcuts.h>
@@ -213,23 +214,52 @@ void YarsConfiguration::__printListCommandFollowModes()
 #endif // USE_VISUALISATION
 }
 
+namespace
+{
+// ".json" extension selects the JSON parse path (yars::parseJsonConfig);
+// anything else (including the "-" stdin sentinel) keeps using the XML/SAX
+// path. Stdin-fed JSON configs are out of scope for Stage 1 — "-" has no
+// filename extension to key off, and JsonParser has no stdin-reading
+// equivalent, so it deliberately stays XML-only.
+bool __isJsonPath(const string &path)
+{
+  static const string suffix = ".json";
+  return path.size() > suffix.size() &&
+         path.compare(path.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+} // namespace
+
 void YarsConfiguration::__readXmlFiles()
 {
   Data::instance()->clear();
   string xml = getXml();
 
-  auto parser = std::make_unique<YarsXSDSaxParser>();
-  // TODO parser should add new xml files to current data-structure (might already be the case?)
-  parser->read(xml);
-  if (parser->errors() > 0)
+  if (__isJsonPath(xml))
   {
-    for (auto i = parser->w_begin(); i != parser->w_end(); ++i)
-      cout << "WARNING: " << *i << endl;
-    for (auto i = parser->e_begin(); i != parser->e_end(); ++i)
-      cout << "ERROR: " << *i << endl;
-    for (auto i = parser->f_begin(); i != parser->f_end(); ++i)
-      cout << "FATAL: " << *i << endl;
-    exit(-1);
+    DataRobotSimulationDescription *spec = Data::instance()->newSpecification();
+    std::vector<string> errors;
+    if (!yars::parseJsonConfig(xml, spec, errors))
+    {
+      for (auto &e : errors)
+        cout << "ERROR: " << e << endl;
+      exit(-1);
+    }
+  }
+  else
+  {
+    auto parser = std::make_unique<YarsXSDSaxParser>();
+    // TODO parser should add new xml files to current data-structure (might already be the case?)
+    parser->read(xml);
+    if (parser->errors() > 0)
+    {
+      for (auto i = parser->w_begin(); i != parser->w_end(); ++i)
+        cout << "WARNING: " << *i << endl;
+      for (auto i = parser->e_begin(); i != parser->e_end(); ++i)
+        cout << "ERROR: " << *i << endl;
+      for (auto i = parser->f_begin(); i != parser->f_end(); ++i)
+        cout << "FATAL: " << *i << endl;
+      exit(-1);
+    }
   }
 
   if (useRandomSeed())

--- a/src/yars/configuration/json/JsonParser.cpp
+++ b/src/yars/configuration/json/JsonParser.cpp
@@ -1,0 +1,150 @@
+#include <yars/configuration/json/JsonParser.h>
+
+#include <yars/configuration/data/DataParseAttribute.h>
+#include <yars/configuration/data/DataParseElement.h>
+#include <yars/configuration/data/DataRobotSimulationDescription.h>
+
+#include <nlohmann/json.hpp>
+
+#include <fstream>
+#include <sstream>
+
+using nlohmann::ordered_json;
+
+namespace yars
+{
+
+namespace
+{
+
+// All attribute values must be stringified before being handed to
+// DataParseAttribute::setValue — the Data* classes' typed accessors
+// (intValue/realValue/boolValue) do atoi/atof/"true"-compare on the stored
+// string (see docs/planning/json-migration-notes.md §1). XmlToJson always
+// emits strings for attribute fields, but be robust to a hand-written or
+// hand-edited JSON config that used a native JSON number/bool.
+std::string toAttributeString(const ordered_json &value)
+{
+  if (value.is_string())
+    return value.get<std::string>();
+  if (value.is_boolean())
+    return value.get<bool>() ? "true" : "false";
+  // Numbers (and anything else scalar): dump() renders a plain textual
+  // form ("3.5", "12", ...) that atof/atoi parse identically to what an
+  // XML attribute string would have looked like.
+  return value.dump();
+}
+
+// Emits the opening/closing DataParseElement event pair for one JSON
+// object representing an element (either a plain child-array entry or a
+// "#children" entry), then recurses into its own children, mirroring the
+// exact sequence YarsXSDSaxHandler::startElement/endElement would produce
+// for the equivalent XML (docs/planning/json-migration-notes.md §1-3).
+//
+// Lifetime rules replayed exactly per the notes: the opening
+// DataParseElement is leaked (never deleted) to match the SAX handler's
+// (confirmed) leak — downstream Data*::add() implementations were audited
+// against that assumption, not against prompt cleanup. The closing
+// DataParseElement is deleted immediately after root->add() returns, also
+// matching the SAX handler.
+void emitElement(const std::string &tag, const ordered_json &object,
+                  DataRobotSimulationDescription *root)
+{
+  DataParseElement *opening =
+      new DataParseElement(YARS_DATA_PARSE_ELEMENT_TYPE_OPENING);
+  opening->setName(tag);
+
+  for (auto it = object.begin(); it != object.end(); ++it)
+  {
+    const std::string &key = it.key();
+    if (key == "#tag" || key == "#children")
+      continue;
+    if (it.value().is_array())
+      continue; // handled as children below, not an attribute
+    DataParseAttribute *attribute = new DataParseAttribute();
+    attribute->setName(key);
+    attribute->setValue(toAttributeString(it.value()));
+    opening->add(attribute);
+  }
+
+  root->add(opening);
+
+  for (auto it = object.begin(); it != object.end(); ++it)
+  {
+    const std::string &key = it.key();
+    const ordered_json &value = it.value();
+
+    if (key == "#children")
+    {
+      for (const auto &child : value)
+      {
+        if (!child.contains("#tag") || !child["#tag"].is_string())
+          throw std::runtime_error(
+              "JSON config: '#children' entry under <" + tag +
+              "> is missing a string '#tag' field");
+        emitElement(child["#tag"].get<std::string>(), child, root);
+      }
+    }
+    else if (value.is_array())
+    {
+      for (const auto &child : value)
+        emitElement(key, child, root);
+    }
+  }
+
+  DataParseElement *closing =
+      new DataParseElement(YARS_DATA_PARSE_ELEMENT_TYPE_CLOSING);
+  closing->setName(tag);
+  root->add(closing);
+  delete closing;
+}
+
+std::string readWholeFile(const std::string &path)
+{
+  std::ifstream file(path, std::ios::in | std::ios::binary);
+  if (!file)
+    throw std::runtime_error("JSON config: could not open '" + path + "'");
+  std::ostringstream contents;
+  contents << file.rdbuf();
+  return contents.str();
+}
+
+} // namespace
+
+bool parseJsonConfig(const std::string &jsonPath,
+                      DataRobotSimulationDescription *root,
+                      std::vector<std::string> &errors)
+{
+  try
+  {
+    // Stdin ("-") is intentionally unsupported here — see JsonParser.h and
+    // YarsConfiguration::__readXmlFiles, where ".json" format detection
+    // never routes "-" to this function.
+    std::string text = readWholeFile(jsonPath);
+    ordered_json document = ordered_json::parse(text);
+
+    if (!document.contains("rosiml") || !document["rosiml"].is_array() ||
+        document["rosiml"].empty())
+    {
+      errors.push_back(jsonPath +
+                        ": missing top-level 'rosiml' element (root of a "
+                        "JSON config must match XmlToJson's output shape)");
+      return false;
+    }
+
+    emitElement("rosiml", document["rosiml"][0], root);
+    return true;
+  }
+  catch (const nlohmann::json::exception &e)
+  {
+    errors.push_back(jsonPath + ": JSON error: " + e.what());
+    return false;
+  }
+  catch (const std::exception &e)
+  {
+    errors.push_back(jsonPath + ": " + e.what());
+    return false;
+  }
+}
+
+} // namespace yars

--- a/src/yars/configuration/json/JsonParser.h
+++ b/src/yars/configuration/json/JsonParser.h
@@ -1,0 +1,47 @@
+#ifndef YARS_CONFIGURATION_JSON_JSON_PARSER_H
+#define YARS_CONFIGURATION_JSON_JSON_PARSER_H
+
+#include <string>
+#include <vector>
+
+class DataRobotSimulationDescription;
+
+namespace yars
+{
+
+/**
+ * Replays the always-arrays JSON produced by XmlToJson (Stage 0) as the
+ * identical DataParseElement open/close event stream that
+ * YarsXSDSaxHandler would emit for the equivalent XML (see
+ * docs/planning/json-migration-notes.md for the full characterization of
+ * that event contract). Feeds events into `root->add(...)` exactly as the
+ * SAX handler does, so all Data* state machines work unchanged.
+ *
+ * Root element must be "rosiml" (matching YARS_STRING_ROSIML) — this is
+ * reproduced structurally here (a JSON object with a top-level "rosiml"
+ * key whose array holds exactly one element), the same shape XmlToJson
+ * always produces for any converted document.
+ *
+ * NOTE: unlike the XML path (YarsXSDSaxParser::read), this reader does not
+ * support "-" (stdin) — stdin JSON configs are out of scope for Stage 1;
+ * see YarsConfiguration::__readXmlFiles for where that is enforced.
+ *
+ * NOTE on validation (Stage 1 known gap, see docs/planning/json-migration-notes.md
+ * §"JSON validation gap"): malformed/incomplete JSON structure (parse
+ * errors, a missing "#tag" inside a "#children" entry, a missing root
+ * "rosiml" key) is caught here and reported cleanly via `errors`. A
+ * missing REQUIRED XML attribute (e.g. <mass kg="..."/> without `kg`) is
+ * NOT guarded here — same as the XML path, which relies on upstream XSD
+ * validation to prevent it from ever reaching the Data* classes. The JSON
+ * path has no equivalent schema validation yet (planned for Stage 4's
+ * binding tables), so a malformed-but-JSON-well-formed config can still
+ * crash inside a Data*::add() unchecked `element->attribute(x)->value()`
+ * dereference. This is a documented, user-visible gap for Stage 1.
+ */
+bool parseJsonConfig(const std::string &jsonPath,
+                      DataRobotSimulationDescription *root,
+                      std::vector<std::string> &errors);
+
+} // namespace yars
+
+#endif // YARS_CONFIGURATION_JSON_JSON_PARSER_H

--- a/src/yars/configuration/json/XmlToJson.cpp
+++ b/src/yars/configuration/json/XmlToJson.cpp
@@ -75,12 +75,17 @@ nlohmann::ordered_json convertElement(DOMElement *element)
     }
   }
 
-  // Walk children once, in document order, tracking contiguous runs of
-  // same-tag siblings. Detect interleaving up front (rule 4) before
-  // grouping anything into arrays (rule 2). Also reject non-whitespace
-  // text content (rule 3).
-  std::vector<std::string> childOrder;    // tag names, in first-seen order
-  std::string lastTag;                    // tag of the previous element child
+  // Walk children once, in document order, collecting (tag, converted-json)
+  // pairs. Also reject non-whitespace text content (rule 3). Grouping into
+  // either the array-by-tag representation (rule 2) or the ordered
+  // '#children' representation (rule 4 amendment) happens in a second pass
+  // below, once we know whether any same-tag siblings are non-contiguous.
+  struct ChildEntry
+  {
+    std::string tag;
+    nlohmann::ordered_json json;
+  };
+  std::vector<ChildEntry> children;
 
   for (DOMNode *child = element->getFirstChild(); child != nullptr;
        child = child->getNextSibling())
@@ -106,34 +111,55 @@ nlohmann::ordered_json convertElement(DOMElement *element)
 
     DOMElement *childElement = static_cast<DOMElement *>(child);
     std::string tag = transcode(childElement->getTagName());
+    children.push_back({tag, convertElement(childElement)});
+  }
 
-    if (tag != lastTag)
+  // Detect whether any same-tag siblings are non-contiguous (interleaved
+  // with a different tag in between). If so, this parent's children are
+  // represented as an ordered '#children' array instead of grouped-by-tag
+  // arrays, preserving document order exactly (rule 4 amendment).
+  bool interleaved = false;
+  {
+    std::vector<std::string> seenTags;
+    std::string lastTag;
+    for (const ChildEntry &entry : children)
     {
-      // Starting a new run. If this tag already appeared earlier under
-      // this parent, the same-tag siblings are non-contiguous, i.e. some
-      // other tag was interleaved between them. That reorders event
-      // order once grouped into arrays, which is the exact hazard rule 4
-      // protects against.
-      for (const std::string &seenTag : childOrder)
+      if (entry.tag == lastTag)
+        continue;
+      for (const std::string &seenTag : seenTags)
       {
-        if (seenTag == tag)
+        if (seenTag == entry.tag)
         {
-          std::string parentName = transcode(element->getTagName());
-          throw std::runtime_error(
-              "xmlToJson: element <" + parentName + "> has non-contiguous "
-              "(interleaved) <" + tag + "> siblings; grouping children by "
-              "tag would silently reorder them. This configuration needs "
-              "an explicit '#children' ordered representation (not yet "
-              "implemented) — refusing to produce an order-lossy JSON "
-              "document.");
+          interleaved = true;
+          break;
         }
       }
-      childOrder.push_back(tag);
-      lastTag = tag;
+      if (interleaved)
+        break;
+      seenTags.push_back(entry.tag);
+      lastTag = entry.tag;
     }
+  }
 
-    nlohmann::ordered_json childJson = convertElement(childElement);
-    object[tag].push_back(childJson);
+  if (interleaved)
+  {
+    nlohmann::ordered_json orderedChildren = nlohmann::ordered_json::array();
+    for (const ChildEntry &entry : children)
+    {
+      // "#tag" is emitted first so a reader can recover the element name
+      // before seeing any of the element's own attributes/children.
+      nlohmann::ordered_json wrapped = nlohmann::ordered_json::object();
+      wrapped["#tag"] = entry.tag;
+      for (auto it = entry.json.begin(); it != entry.json.end(); ++it)
+        wrapped[it.key()] = it.value();
+      orderedChildren.push_back(wrapped);
+    }
+    object["#children"] = orderedChildren;
+  }
+  else
+  {
+    for (const ChildEntry &entry : children)
+      object[entry.tag].push_back(entry.json);
   }
 
   return object;

--- a/src/yars/configuration/json/XmlToJson.h
+++ b/src/yars/configuration/json/XmlToJson.h
@@ -32,9 +32,13 @@ namespace yars
  *      silently reorder interleaved same-tag siblings
  *      (<proximity/><velocity/><proximity/> → both proximities adjacent).
  *      The converter therefore DETECTS non-contiguous same-tag siblings
- *      under any parent and fails loudly (throws std::runtime_error naming
- *      the parent element), rather than silently producing an
- *      order-lossy — and therefore semantically wrong — JSON document.
+ *      under any parent and, for that parent only, represents its children
+ *      as an ordered `"#children": [ {"#tag": "<name>", ...}, ... ]` array
+ *      in document order instead of grouping by tag. Each entry carries its
+ *      original tag name under the reserved key `"#tag"` (emitted first).
+ *      Contiguous same-tag runs elsewhere still use the plain
+ *      grouped-by-tag array form (rule 2) — `#children` is only used where
+ *      it is structurally necessary to preserve order.
  *
  * Uses nlohmann::ordered_json (not nlohmann::json) throughout: insertion
  * order of object keys is load-bearing for rule 4's guarantee that

--- a/tests/unit/test_xml_to_json.cpp
+++ b/tests/unit/test_xml_to_json.cpp
@@ -13,10 +13,50 @@ TEST(XmlToJson, AttributesBecomeStringFieldsChildrenBecomeArrays)
   EXPECT_EQ(j["root"][0]["child"][1]["b"], "y");
 }
 
-TEST(XmlToJson, InterleavedSameTagSiblingsFailLoudly)
+TEST(XmlToJson, InterleavedSameTagSiblingsBecomeOrderedChildren)
 {
   const char *xml = "<root><a x=\"1\"/><b/><a x=\"2\"/></root>";
   std::string p = testing::TempDir() + "xmltojson_interleaved.xml";
   { std::ofstream f(p); f << xml; }
-  EXPECT_THROW(yars::xmlToJson(p), std::runtime_error);   // order-lossy input must be rejected
+  auto j = yars::xmlToJson(p);
+  auto &r = j["root"][0];
+
+  ASSERT_TRUE(r.contains("#children"));
+  ASSERT_FALSE(r.contains("a"));   // grouped-by-tag form must not also appear
+  ASSERT_FALSE(r.contains("b"));
+
+  auto &children = r["#children"];
+  ASSERT_EQ(children.size(), 3u);
+  EXPECT_EQ(children[0]["#tag"], "a");
+  EXPECT_EQ(children[0]["x"], "1");
+  EXPECT_EQ(children[1]["#tag"], "b");
+  EXPECT_EQ(children[2]["#tag"], "a");
+  EXPECT_EQ(children[2]["x"], "2");   // document order preserved, not grouped
+}
+
+TEST(XmlToJson, MixedContiguousParentsKeepArrayFormInterleavedGetChildren)
+{
+  // <outer> has contiguous <same> runs (array form preserved) but its
+  // <mid> child has interleaved <a>/<b> siblings (#children form).
+  const char *xml =
+      "<outer>"
+      "<same n=\"1\"/><same n=\"2\"/>"
+      "<mid><a x=\"1\"/><b/><a x=\"2\"/></mid>"
+      "</outer>";
+  std::string p = testing::TempDir() + "xmltojson_mixed.xml";
+  { std::ofstream f(p); f << xml; }
+  auto j = yars::xmlToJson(p);
+  auto &outer = j["outer"][0];
+
+  ASSERT_FALSE(outer.contains("#children"));
+  ASSERT_TRUE(outer.contains("same"));
+  EXPECT_EQ(outer["same"].size(), 2u);
+  ASSERT_TRUE(outer.contains("mid"));
+
+  auto &mid = outer["mid"][0];
+  ASSERT_TRUE(mid.contains("#children"));
+  EXPECT_EQ(mid["#children"].size(), 3u);
+  EXPECT_EQ(mid["#children"][0]["#tag"], "a");
+  EXPECT_EQ(mid["#children"][1]["#tag"], "b");
+  EXPECT_EQ(mid["#children"][2]["#tag"], "a");
 }


### PR DESCRIPTION
Stage 1 of docs/superpowers/plans/2026-07-06-json-config-migration.md. **After this PR, one YARS version parses both XML and JSON** (selected by file extension); XML behavior is byte-identical to before.

## What this adds
- `JsonParser`: replays the exact `DataParseElement` event stream from ordered JSON — all ~190 Data* classes parse JSON with zero per-class changes. Fidelity verified against the SAX handler line-by-line (localname tags, string attributes, identical lifetime rules including the original's known leak — bit-exactness beats hygiene, tracked for Stage 4)
- `#children` ordered representation (converter + reader): the 6 order-lossy configs found in Stage 0 now convert with exact document-order preservation — 29/29 corpus conversion; external controllers' index bindings safe
- Format detection by `.json` extension at the single config entry point; stdin stays XML
- `scripts/json-roundtrip-check.sh`: 13-config CI-corpus round-trip verification
- Parse-event contract characterization committed (`docs/planning/json-migration-notes.md`)

## Verification (all independently re-run at stage review)
- 38/38 tests; 29/29 corpus conversion; 13/13 round trips
- **Acceptance: braitenberg_logging.json and hexapod_logging.json (2000 iters) bit-exact vs the committed platform reference CSVs** — JSON-parsed configs reproduce XML-generated references byte-for-byte
- GUI clean from a .json config; malformed-JSON and wrong-root inputs fail with clean errors

## Sign-off note (documented ruling)
Hand-edited JSON missing a required attribute is not yet structurally validated (crashes in unchanged Data* code, as hand-edited XML would without XSD). The generic guard was evaluated and rejected on the merits (optional-attribute access is pervasive and indistinguishable). Gap documented in notes §8 incl. the convert-only-known-valid-XML caveat; the tracked fix is Stage 4's binding tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)