### PR TITLE
JSON migration Stage 2: corpus committed, CI runs on JSON

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -125,7 +125,7 @@ jobs:
         env:
           LD_LIBRARY_PATH: ${{ env.OGRE_INSTALL_PREFIX }}/lib:${{ env.BULLET_INSTALL_PREFIX }}/lib
         run: |
-          ./build/bin/yars --iterations 100 --nogui --xml xml/braitenberg_nocontroller.xml
+          ./build/bin/yars --iterations 100 --nogui --xml xml/braitenberg_nocontroller.json
 
       - name: Locate contrib controller libraries
         id: contrib
@@ -147,16 +147,16 @@ jobs:
           mkdir -p linux-audit-logs
           FAILED=0
           STANDALONE=(
-            xml/braitenberg_nocontroller.xml
-            xml/falling_objects.xml
-            xml/test_capture.xml
+            xml/braitenberg_nocontroller.json
+            xml/falling_objects.json
+            xml/test_capture.json
           )
           # cd into build/ so YARS resolves controller .so files via cwd/lib.
           # --lib arg is only validated by YARS, not added to the candidate
           # search path, so the cwd/lib fallback is the working pattern.
           cd build
           for cfg in "${STANDALONE[@]}"; do
-            name=$(basename "$cfg" .xml)
+            name=$(basename "$cfg" .json)
             log="../linux-audit-logs/${name}.log"
             # 60s per-config wall-clock cap so any hang fails fast rather
             # than burning the whole 90-min job budget.
@@ -178,15 +178,15 @@ jobs:
           FAILED=0
           # Map of XML config -> required controller lib name (no prefix/suffix)
           declare -A CFG2LIB=(
-            ["xml/braitenberg.xml"]="YarsControllerBraitenberg2b"
-            ["xml/braitenberg_noise.xml"]="YarsControllerBraitenberg2b"
-            ["xml/braitenberg_logging.xml"]="YarsControllerBraitenberg3b"
-            ["xml/braitenberg_light_source.xml"]="YarsControllerBraitenberg2b"
-            ["xml/braitenberg_trace_projection.xml"]="YarsControllerBraitenberg2b"
-            ["xml/braitenberg_zoo.xml"]="YarsControllerBraitenberg2a"
-            ["xml/muscle.xml"]="YarsControllerSquareWave"
-            ["xml/joints/generic_angular.xml"]="YarsControllerSine"
-            ["xml/joints/generic_force.xml"]="YarsControllerSine"
+            ["xml/braitenberg.json"]="YarsControllerBraitenberg2b"
+            ["xml/braitenberg_noise.json"]="YarsControllerBraitenberg2b"
+            ["xml/braitenberg_logging.json"]="YarsControllerBraitenberg3b"
+            ["xml/braitenberg_light_source.json"]="YarsControllerBraitenberg2b"
+            ["xml/braitenberg_trace_projection.json"]="YarsControllerBraitenberg2b"
+            ["xml/braitenberg_zoo.json"]="YarsControllerBraitenberg2a"
+            ["xml/muscle.json"]="YarsControllerSquareWave"
+            ["xml/joints/generic_angular.json"]="YarsControllerSine"
+            ["xml/joints/generic_force.json"]="YarsControllerSine"
           )
           # cd into build/ so YARS resolves controller .so files via cwd/lib.
           # --lib arg is only validated by YARS, not added to the candidate
@@ -195,7 +195,7 @@ jobs:
           for cfg in "${!CFG2LIB[@]}"; do
             libname="${CFG2LIB[$cfg]}"
             libfile="lib/lib${libname}.so"
-            name=$(basename "$cfg" .xml)
+            name=$(basename "$cfg" .json)
             log="../linux-audit-logs/${name}.log"
             if [ ! -f "$libfile" ]; then
               echo "${cfg}: SKIP (lib ${libfile} not found)" | tee -a ../linux-audit-logs/summary.txt
@@ -217,7 +217,7 @@ jobs:
           cd ..
           exit $FAILED
 
-      - name: Reference CSV regression check (braitenberg_logging.xml)
+      - name: Reference CSV regression check (braitenberg_logging.json)
         env:
           LD_LIBRARY_PATH: ${{ env.OGRE_INSTALL_PREFIX }}/lib:${{ env.BULLET_INSTALL_PREFIX }}/lib
         run: |
@@ -226,7 +226,7 @@ jobs:
           rm -f braitenberg-*.csv
           # Bound the run; the XML has no built-in stop condition so an
           # unbounded invocation runs until the 90-min job timeout.
-          timeout 120s ./bin/yars --iterations 2000 --nogui --xml ../xml/braitenberg_logging.xml
+          timeout 120s ./bin/yars --iterations 2000 --nogui --xml ../xml/braitenberg_logging.json
           ACTUAL=$(ls -t braitenberg-*.csv | head -1)
           if [ -z "$ACTUAL" ]; then
             echo "No braitenberg-*.csv produced"
@@ -257,13 +257,44 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
-      - name: Reference CSV regression check (hexapod_logging.xml)
+      - name: XML-path guard (until Stage 3)
+        env:
+          LD_LIBRARY_PATH: ${{ env.OGRE_INSTALL_PREFIX }}/lib:${{ env.BULLET_INSTALL_PREFIX }}/lib
+        run: |
+          # Keeps the legacy XML parse path exercised in CI until Stage 3
+          # deletes the XML corpus. Runs the same braitenberg_logging config
+          # from .xml and diffs against the same reference used for the
+          # JSON gate above — the two paths must stay bit-identical.
+          cd build
+          rm -f braitenberg-*.csv
+          timeout 120s ./bin/yars --iterations 2000 --nogui --xml ../xml/braitenberg_logging.xml
+          ACTUAL=$(ls -t braitenberg-*.csv | head -1)
+          if [ -z "$ACTUAL" ]; then
+            echo "No braitenberg-*.csv produced (XML path)"
+            exit 1
+          fi
+          mv "$ACTUAL" braitenberg_logging_actual_xml.csv
+          cd ..
+          REF=xml/reference_logfile.linux-x86_64.csv
+          if [ ! -f "$REF" ]; then
+            echo "::warning::No Linux x86_64 reference committed yet; skipping XML-path guard diff."
+          else
+            if diff -u "$REF" build/braitenberg_logging_actual_xml.csv > csv-diff-xml.log; then
+              echo "XML-path CSV byte-identical to $REF."
+            else
+              echo "::error::XML-path CSV differs from $REF — see csv-diff-xml.log artifact."
+              head -50 csv-diff-xml.log
+              exit 1
+            fi
+          fi
+
+      - name: Reference CSV regression check (hexapod_logging.json)
         env:
           LD_LIBRARY_PATH: ${{ env.OGRE_INSTALL_PREFIX }}/lib:${{ env.BULLET_INSTALL_PREFIX }}/lib
         run: |
           cd build
           rm -f hexapod-*.csv
-          timeout 120s ./bin/yars --iterations 2000 --nogui --xml ../xml/hexapod_logging.xml
+          timeout 120s ./bin/yars --iterations 2000 --nogui --xml ../xml/hexapod_logging.json
           ACTUAL=$(ls -t hexapod-*.csv | head -1)
           if [ -z "$ACTUAL" ]; then
             echo "No hexapod-*.csv produced"
@@ -299,8 +330,8 @@ jobs:
           LD_LIBRARY_PATH: ${{ env.OGRE_INSTALL_PREFIX }}/lib:${{ env.BULLET_INSTALL_PREFIX }}/lib
         run: |
           set -e
-          if [ ! -f xml/test_capture.xml ]; then
-            echo "::warning::xml/test_capture.xml not present, skipping capture step"
+          if [ ! -f xml/test_capture.json ]; then
+            echo "::warning::xml/test_capture.json not present, skipping capture step"
             exit 0
           fi
           # Ogre::Root("plugins.cfg", "ogre.cfg", "") uses cwd-relative
@@ -326,7 +357,7 @@ jobs:
               --capture \
               --captureDirectory . \
               --captureName yars-capture.mp4 \
-              --xml ../xml/test_capture.xml \
+              --xml ../xml/test_capture.json \
             > ../linux-audit-logs/video-capture.log 2>&1
           # YARS writes per-segment captures named <base>-NNNN.mp4 (see
           # WindowConfiguration::getNextCaptureName). For our 1800-iter

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -115,21 +115,21 @@ jobs:
       - name: Smoke test (--nogui, 100 iterations)
         run: |
           cd build
-          ./bin/yars --iterations 100 --nogui --xml ../xml/braitenberg_nocontroller.xml
+          ./bin/yars --iterations 100 --nogui --xml ../xml/braitenberg_nocontroller.json
 
       - name: Smoke test with controller (--nogui, 100 iterations)
         run: |
           cd build
-          ./bin/yars --iterations 100 --nogui --xml ../xml/braitenberg.xml
+          ./bin/yars --iterations 100 --nogui --xml ../xml/braitenberg.json
 
-      - name: Reference CSV regression check (braitenberg_logging.xml)
+      - name: Reference CSV regression check (braitenberg_logging.json)
         run: |
           cd build
           rm -f braitenberg-*.csv
           # macOS arm64 hits 2000 iters in ~5s. No external timeout
           # wrapper because BSD doesn't ship GNU `timeout`; the
           # --iterations flag is the stop condition.
-          ./bin/yars --iterations 2000 --nogui --xml ../xml/braitenberg_logging.xml
+          ./bin/yars --iterations 2000 --nogui --xml ../xml/braitenberg_logging.json
           ACTUAL=$(ls -t braitenberg-*.csv | head -1)
           if [ -z "$ACTUAL" ]; then
             echo "No braitenberg-*.csv produced"
@@ -160,14 +160,14 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
-      - name: Reference CSV regression check (hexapod_logging.xml)
+      - name: Reference CSV regression check (hexapod_logging.json)
         run: |
           cd build
           rm -f hexapod-*.csv
           # macOS arm64 hits 2000 iters in ~5s. No external timeout
           # wrapper because BSD doesn't ship GNU `timeout`; the
           # --iterations flag is the stop condition.
-          ./bin/yars --iterations 2000 --nogui --xml ../xml/hexapod_logging.xml
+          ./bin/yars --iterations 2000 --nogui --xml ../xml/hexapod_logging.json
           ACTUAL=$(ls -t hexapod-*.csv | head -1)
           if [ -z "$ACTUAL" ]; then
             echo "No hexapod-*.csv produced"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,22 +116,22 @@ cmake ..
 make -j4
 
 # Test the build
-./bin/yars --iterations 1000 --xml ../xml/braitenberg_logging.xml
+./bin/yars --iterations 1000 --xml ../xml/braitenberg_logging.json
 ```
 
 ### Validation Commands
 ```bash
 # Basic simulation test
-./bin/yars --iterations 1000 --xml xml/braitenberg_logging.xml
+./bin/yars --iterations 1000 --xml xml/braitenberg_logging.json
 
 # Compare with reference logfile
 diff braitenberg-*.csv ../xml/reference_logfile.macos-arm64.csv
 
 # Performance test  
-time ./bin/yars --iterations 10000 --xml xml/falling_objects.xml
+time ./bin/yars --iterations 10000 --xml xml/falling_objects.json
 
 # Memory validation
-valgrind --leak-check=full ./bin/yars --iterations 100 --xml xml/braitenberg.xml
+valgrind --leak-check=full ./bin/yars --iterations 100 --xml xml/braitenberg.json
 ```
 
 ## Modernization Achievements
@@ -185,7 +185,7 @@ valgrind --leak-check=full ./bin/yars --iterations 100 --xml xml/braitenberg.xml
 - **Headers**: Include guards and minimal dependencies
 
 ### Testing Protocol
-- **Regression**: Always test with `braitenberg_logging.xml`
+- **Regression**: Always test with `braitenberg_logging.json`
 - **Validation**: Compare logfile output with reference
 - **Build**: Clean build required after significant changes
 - **Memory**: Run valgrind for memory leak detection
@@ -261,13 +261,13 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 ### Test Commands
 ```bash
 # Basic functionality
-./bin/yars --iterations 1000 --xml xml/braitenberg_logging.xml
+./bin/yars --iterations 1000 --xml xml/braitenberg_logging.json
 
 # No GUI mode
-./bin/yars --iterations 1000 --xml xml/braitenberg_logging.xml --no-gui
+./bin/yars --iterations 1000 --xml xml/braitenberg_logging.json --no-gui
 
 # Performance test
-time ./bin/yars --iterations 10000 --xml xml/falling_objects.xml
+time ./bin/yars --iterations 10000 --xml xml/falling_objects.json
 ```
 
 ### Analysis Commands

--- a/scripts/json-roundtrip-check.sh
+++ b/scripts/json-roundtrip-check.sh
@@ -9,6 +9,16 @@
 #     bit-exact CSV diff.
 #   - everything else: exit code + final console line.
 #
+# Corpus is read-only: the committed xml/*.json twins are never written or
+# deleted by this script. --convert writes its output next to whatever
+# input path it is given, so the source .xml is copied into the $WORKDIR
+# scratch tree first and converted there. The freshly-converted
+# $WORKDIR/<name>.json is then diffed byte-for-byte against the committed
+# xml/<name>.json ("DRIFT" failure if they differ) and is also the file the
+# JSON-side simulation run is executed from (proving the converter's actual
+# output, not the pre-existing corpus copy). $WORKDIR is removed via the
+# EXIT trap, so nothing under xml/ is ever touched.
+#
 # Usage: scripts/json-roundtrip-check.sh <build-dir>   (default: build)
 
 set -u
@@ -70,10 +80,15 @@ run_one() {
   TOTAL=$((TOTAL + 1))
 
   local xmlpath="$ROOT/$cfg"
-  local jsonpath="${xmlpath%.xml}.json"
+  local corpus_jsonpath="${xmlpath%.xml}.json"
 
-  # 1. Convert.
-  if ! timeout 30s "$YARS_BIN" --convert "$xmlpath" >"$WORKDIR/${name}-convert.log" 2>&1; then
+  # 1. Convert. --convert writes its output next to the INPUT path, so copy
+  # the .xml into the scratch dir and convert there — the committed corpus
+  # (both the .xml and its .json twin) is never written to.
+  local scratch_xml="$WORKDIR/${name}.xml"
+  local jsonpath="$WORKDIR/${name}.json"
+  cp "$xmlpath" "$scratch_xml"
+  if ! timeout 30s "$YARS_BIN" --convert "$scratch_xml" >"$WORKDIR/${name}-convert.log" 2>&1; then
     echo "FAIL $cfg (conversion failed, see $WORKDIR/${name}-convert.log)"
     sed 's/^/  /' "$WORKDIR/${name}-convert.log"
     FAILED=1
@@ -81,6 +96,21 @@ run_one() {
   fi
   if [[ ! -f "$jsonpath" ]]; then
     echo "FAIL $cfg (conversion did not produce $jsonpath)"
+    FAILED=1
+    return
+  fi
+
+  # 1b. Corpus-drift check: the freshly-converted JSON must be byte-identical
+  # to the committed twin. A mismatch means the corpus is stale relative to
+  # the converter and needs regenerating (and re-committing) deliberately.
+  if [[ ! -f "$corpus_jsonpath" ]]; then
+    echo "FAIL $cfg (DRIFT: no committed corpus twin at $corpus_jsonpath)"
+    FAILED=1
+    return
+  fi
+  if ! diff -q "$jsonpath" "$corpus_jsonpath" >/dev/null; then
+    echo "FAIL $cfg (DRIFT: converted JSON differs from committed $corpus_jsonpath)"
+    diff "$jsonpath" "$corpus_jsonpath" | head -20
     FAILED=1
     return
   fi
@@ -155,7 +185,6 @@ run_one() {
     echo "PASS $cfg (exit=$xml_rc, final line matches)"
   fi
   PASSED=$((PASSED + 1))
-  rm -f "$jsonpath"
 }
 
 for cfg in "${STANDALONE[@]}"; do

--- a/scripts/perf-measure.sh
+++ b/scripts/perf-measure.sh
@@ -12,7 +12,7 @@ now() { python3 -c 'import time; print(time.time())'; }
 cd "$BUILD_DIR"
 START=$(now)
 ${TIMEOUT_BIN:+$TIMEOUT_BIN 600s} ./bin/yars --iterations $ITER --nogui \
-  --xml "$ROOT/xml/braitenberg.xml" > /dev/null 2>&1
+  --xml "$ROOT/xml/braitenberg.json" > /dev/null 2>&1
 END=$(now)
 SPS=$(echo "$ITER $END $START" | awk '{printf "%.0f", $1/($2-$3)}')
 SHA=$(git -C "$ROOT" rev-parse --short HEAD)

--- a/scripts/sanitize-corpus.sh
+++ b/scripts/sanitize-corpus.sh
@@ -17,28 +17,28 @@ export LSAN_OPTIONS="suppressions=$SUPP"
 
 # Standalone configs (no controller library needed)
 STANDALONE=(
-  xml/braitenberg_nocontroller.xml
-  xml/falling_objects.xml
-  xml/test_capture.xml
-  xml/hexapod_logging.xml
+  xml/braitenberg_nocontroller.json
+  xml/falling_objects.json
+  xml/test_capture.json
+  xml/hexapod_logging.json
 )
 # Controller-based configs: config -> lib name (mirrors linux-build.yml)
 CONFIGS=(
-  "xml/braitenberg.xml:YarsControllerBraitenberg2b"
-  "xml/braitenberg_noise.xml:YarsControllerBraitenberg2b"
-  "xml/braitenberg_logging.xml:YarsControllerBraitenberg3b"
-  "xml/braitenberg_light_source.xml:YarsControllerBraitenberg2b"
-  "xml/braitenberg_trace_projection.xml:YarsControllerBraitenberg2b"
-  "xml/braitenberg_zoo.xml:YarsControllerBraitenberg2a"
-  "xml/muscle.xml:YarsControllerSquareWave"
-  "xml/joints/generic_angular.xml:YarsControllerSine"
-  "xml/joints/generic_force.xml:YarsControllerSine"
+  "xml/braitenberg.json:YarsControllerBraitenberg2b"
+  "xml/braitenberg_noise.json:YarsControllerBraitenberg2b"
+  "xml/braitenberg_logging.json:YarsControllerBraitenberg3b"
+  "xml/braitenberg_light_source.json:YarsControllerBraitenberg2b"
+  "xml/braitenberg_trace_projection.json:YarsControllerBraitenberg2b"
+  "xml/braitenberg_zoo.json:YarsControllerBraitenberg2a"
+  "xml/muscle.json:YarsControllerSquareWave"
+  "xml/joints/generic_angular.json:YarsControllerSine"
+  "xml/joints/generic_force.json:YarsControllerSine"
 )
 
 FAILED=0
 cd "$BUILD_DIR"
 for cfg in "${STANDALONE[@]}"; do
-  name=$(basename "$cfg" .xml)
+  name=$(basename "$cfg" .json)
   # Sanitized builds are ~2-4x slower: 240s cap, 500 iterations
   if timeout 240s ./bin/yars --iterations 500 --nogui --xml "$ROOT/$cfg" > "san-${name}.log" 2>&1; then
     echo "PASS $cfg"
@@ -48,7 +48,7 @@ for cfg in "${STANDALONE[@]}"; do
 done
 for entry in "${CONFIGS[@]}"; do
   cfg="${entry%%:*}"; lib="${entry##*:}"
-  name=$(basename "$cfg" .xml)
+  name=$(basename "$cfg" .json)
   if ! ls lib/lib${lib}.* >/dev/null 2>&1; then
     echo "FAIL $cfg (lib${lib} missing)"; FAILED=1; continue
   fi

--- a/scripts/sanitizer-suppressions.txt
+++ b/scripts/sanitizer-suppressions.txt
@@ -21,6 +21,11 @@ leak:xercesc_3_2::
 # --- for the Data*/XSD layer; physics-layer entries are unique_ptr
 # --- candidates recorded in docs/planning/v0.8.7-open-points.md).
 leak:YarsXSDSaxHandler::startElement
+# Same leak, JSON path: JsonParser deliberately mirrors the SAX handler's
+# opening-element lifetime (bit-exactness contract, Stage 1) — the
+# allocation site is emitElement/parseJsonConfig instead of the handler.
+# Retired together with the parse-layer rework (Stage 3/4).
+leak:parseJsonConfig
 leak:createXsd
 leak:XsdSpecification
 leak:YarsXSDSaxParser::read

--- a/xml/ant.json
+++ b/xml/ant.json
@@ -1,0 +1,1514 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "capture": "false",
+              "follow": "true",
+              "name": "main",
+              "show": "true",
+              "resolution": [
+                {
+                  "name": "720p"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "3.00",
+                      "y": "-2.00",
+                      "z": "2.5"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.0",
+                      "z": "0.55"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "-0.3",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.25"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.25"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.000",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.50"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.50"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.00"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "name": "env",
+          "ground": [
+            {
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGround"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "ant",
+              "body": [
+                {
+                  "selfCollide": "false",
+                  "box": [
+                    {
+                      "name": "body",
+                      "dimension": [
+                        {
+                          "depth": "1.0",
+                          "height": "0.1",
+                          "width": "0.3"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.55"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "first": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "second": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "third": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "fourth": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "fifth": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "sixth": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0.1"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "capsule": [
+                    {
+                      "name": "left front femur",
+                      "dimension": [
+                        {
+                          "height": "0.224",
+                          "radius": "0.05"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90.0",
+                          "x": "0.25",
+                          "y": "-0.5",
+                          "z": "0.55"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0.1"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left front tibia",
+                      "dimension": [
+                        {
+                          "height": "0.45",
+                          "radius": "0.05"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "0.0",
+                          "x": "0.362",
+                          "y": "-0.5",
+                          "z": "0.325"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0.5"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right front femur",
+                      "dimension": [
+                        {
+                          "height": "0.224",
+                          "radius": "0.05"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "-90.0",
+                          "x": "-0.25",
+                          "y": "-0.5",
+                          "z": "0.55"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0.1"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right front tibia",
+                      "dimension": [
+                        {
+                          "height": "0.45",
+                          "radius": "0.05"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "0.0",
+                          "x": "-0.362",
+                          "y": "-0.5",
+                          "z": "0.325"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0.5"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left centre femur",
+                      "dimension": [
+                        {
+                          "height": "0.224",
+                          "radius": "0.05"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90.0",
+                          "x": "0.25",
+                          "y": "0.0",
+                          "z": "0.55"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0.1"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left centre tibia",
+                      "dimension": [
+                        {
+                          "height": "0.45",
+                          "radius": "0.05"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "0.0",
+                          "x": "0.362",
+                          "y": "0.0",
+                          "z": "0.325"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0.5"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right centre femur",
+                      "dimension": [
+                        {
+                          "height": "0.224",
+                          "radius": "0.05"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "-90.0",
+                          "x": "-0.25",
+                          "y": "0.0",
+                          "z": "0.55"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0.1"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right centre tibia",
+                      "dimension": [
+                        {
+                          "height": "0.45",
+                          "radius": "0.05"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "0.0",
+                          "x": "-0.362",
+                          "y": "0.0",
+                          "z": "0.325"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0.5"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left back femur",
+                      "dimension": [
+                        {
+                          "height": "0.224",
+                          "radius": "0.05"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90.0",
+                          "x": "0.25",
+                          "y": "0.5",
+                          "z": "0.55"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0.1"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left back tibia",
+                      "dimension": [
+                        {
+                          "height": "0.45",
+                          "radius": "0.05"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "0.0",
+                          "x": "0.362",
+                          "y": "0.5",
+                          "z": "0.325"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0.5"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right back femur",
+                      "dimension": [
+                        {
+                          "height": "0.224",
+                          "radius": "0.05"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "-90.0",
+                          "x": "-0.25",
+                          "y": "0.5",
+                          "z": "0.55"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0.1"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right back tibia",
+                      "dimension": [
+                        {
+                          "height": "0.45",
+                          "radius": "0.05"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "0.0",
+                          "x": "-0.362",
+                          "y": "0.5",
+                          "z": "0.325"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0.5"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "passive",
+                      "name": "left front hip",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left front femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.15",
+                          "y": "-0.5",
+                          "z": "0.55"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "4.0",
+                          "restitution": "0.0",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.0",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "passive",
+                      "name": "right front hip",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right front femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "-0.15",
+                          "y": "-0.5",
+                          "z": "0.55"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "4.0",
+                          "restitution": "0.0",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.0",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "passive",
+                      "name": "left centre hip",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left centre femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.15",
+                          "y": "0.0",
+                          "z": "0.55"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "4.0",
+                          "restitution": "0.0",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.0",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "passive",
+                      "name": "right centre hip",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right centre femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "-0.15",
+                          "y": "0.0",
+                          "z": "0.55"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "4.0",
+                          "restitution": "0.0",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.0",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "passive",
+                      "name": "left back hip",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left back femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.15",
+                          "y": "0.5",
+                          "z": "0.55"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "4.0",
+                          "restitution": "0.0",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.0",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "passive",
+                      "name": "right back hip",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right back femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "-0.15",
+                          "y": "0.5",
+                          "z": "0.55"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "4.0",
+                          "restitution": "0.0",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.0",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "passive",
+                      "name": "left front knee",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left front tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left front femur"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "3.5"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.362",
+                          "y": "-0.5",
+                          "z": "0.55"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "15.0",
+                          "min": "-15.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "4.0",
+                          "restitution": "0.0",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.0",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "passive",
+                      "name": "right front knee",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right front tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right front femur"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "3.5"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "-0.362",
+                          "y": "-0.5",
+                          "z": "0.55"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "15.0",
+                          "min": "-15.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "4.0",
+                          "restitution": "0.0",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.0",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "passive",
+                      "name": "left centre knee",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left centre tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left centre femur"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "3.5"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.362",
+                          "y": "0.0",
+                          "z": "0.55"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "15.0",
+                          "min": "-15.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "4.0",
+                          "restitution": "0.0",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.0",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "passive",
+                      "name": "right centre knee",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right centre tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right centre femur"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "3.5"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "-0.362",
+                          "y": "0.0",
+                          "z": "0.55"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "15.0",
+                          "min": "-15.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "4.0",
+                          "restitution": "0.0",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.0",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "passive",
+                      "name": "left back knee",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left back tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left back femur"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "3.5"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.362",
+                          "y": "0.5",
+                          "z": "0.55"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "15.0",
+                          "min": "-15.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "4.0",
+                          "restitution": "0.0",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.0",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "passive",
+                      "name": "right back knee",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right back tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right back femur"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "3.5"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "-0.362",
+                          "y": "0.5",
+                          "z": "0.55"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "15.0",
+                          "min": "-15.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "4.0",
+                          "restitution": "0.0",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.0",
+                          "size": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/braitenberg.json
+++ b/xml/braitenberg.json
@@ -1,0 +1,1118 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Braiternberg",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "0.00",
+                      "y": "0.00",
+                      "z": "10"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "wall 1",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 2",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Blue"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 3",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 4",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "-4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Braitenberg",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Green"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "15",
+                  "x": "2.25",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "left 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Braitenberg2b"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "5",
+              "max": "300",
+              "particles": "false",
+              "target": "main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "200",
+              "particles": "false",
+              "target": "wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "100",
+              "particles": "false",
+              "target": "wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/braitenberg_controller_go.json
+++ b/xml/braitenberg_controller_go.json
@@ -1,0 +1,1177 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.40",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Braiternberg 6 inputs",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "0.00",
+                      "y": "0.00",
+                      "z": "10"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "gravitation": [
+            {
+              "x": "0.0",
+              "y": "0.0",
+              "z": "-9.81"
+            }
+          ],
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "wall 1",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 2",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Blue"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 3",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 4",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "-4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Braitenberg",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Green"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "15",
+                  "x": "2.25",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "left 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ],
+                  "ov": [
+                    {
+                      "name": "main body velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "oav": [
+                    {
+                      "name": "main body angular velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "position": [
+                    {
+                      "name": "main body position",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Go",
+                  "parameter": [
+                    {
+                      "name": "go controller",
+                      "value": "./lib/braitenberg_go.dylib"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "5",
+              "max": "300",
+              "particles": "false",
+              "target": "main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "200",
+              "particles": "false",
+              "target": "wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "100",
+              "particles": "false",
+              "target": "wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/braitenberg_controller_go_gui.json
+++ b/xml/braitenberg_controller_go_gui.json
@@ -1,0 +1,1177 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Braiternberg 6 inputs",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "0.00",
+                      "y": "0.00",
+                      "z": "10"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "gravitation": [
+            {
+              "x": "0.0",
+              "y": "0.0",
+              "z": "-9.81"
+            }
+          ],
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "wall 1",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 2",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Blue"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 3",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 4",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "-4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Braitenberg",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Green"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "15",
+                  "x": "2.25",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "left 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ],
+                  "ov": [
+                    {
+                      "name": "main body velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "oav": [
+                    {
+                      "name": "main body angular velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "position": [
+                    {
+                      "name": "main body position",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Go",
+                  "parameter": [
+                    {
+                      "name": "go controller",
+                      "value": "./lib/gogui.dylib"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "5",
+              "max": "300",
+              "particles": "false",
+              "target": "main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "200",
+              "particles": "false",
+              "target": "wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "100",
+              "particles": "false",
+              "target": "wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/braitenberg_controller_julia.json
+++ b/xml/braitenberg_controller_julia.json
@@ -1,0 +1,1185 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.40",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Braiternberg 6 inputs",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "0.00",
+                      "y": "0.00",
+                      "z": "10"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "gravitation": [
+            {
+              "x": "0.0",
+              "y": "0.0",
+              "z": "-9.81"
+            }
+          ],
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "wall 1",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 2",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Blue"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 3",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 4",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "-4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Braitenberg",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Green"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "15",
+                  "x": "2.25",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "left 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ],
+                  "ov": [
+                    {
+                      "name": "main body velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "oav": [
+                    {
+                      "name": "main body angular velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "position": [
+                    {
+                      "name": "main body position",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Julia",
+                  "parameter": [
+                    {
+                      "name": "debug",
+                      "value": "true"
+                    },
+                    {
+                      "name": "file name",
+                      "value": "/Users/zahedi/projects/yars/contrib/controller/braitenberg.jl"
+                    },
+                    {
+                      "name": "evaluation line 1",
+                      "value": "test_function()"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "5",
+              "max": "300",
+              "particles": "false",
+              "target": "main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "200",
+              "particles": "false",
+              "target": "wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "100",
+              "particles": "false",
+              "target": "wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/braitenberg_controller_matlab.json
+++ b/xml/braitenberg_controller_matlab.json
@@ -1,0 +1,1185 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.40",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Braiternberg 6 inputs",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "0.00",
+                      "y": "0.00",
+                      "z": "10"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "gravitation": [
+            {
+              "x": "0.0",
+              "y": "0.0",
+              "z": "-9.81"
+            }
+          ],
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "wall 1",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 2",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Blue"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 3",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 4",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "-4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Braitenberg",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Green"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "15",
+                  "x": "2.25",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "left 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ],
+                  "ov": [
+                    {
+                      "name": "main body velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "oav": [
+                    {
+                      "name": "main body angular velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "position": [
+                    {
+                      "name": "main body position",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "MATLAB",
+                  "parameter": [
+                    {
+                      "name": "debug",
+                      "value": "true"
+                    },
+                    {
+                      "name": "update",
+                      "value": "bb_update"
+                    },
+                    {
+                      "name": "working directory",
+                      "value": "/Users/zahedi/projects/yars/contrib/controller"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "5",
+              "max": "300",
+              "particles": "false",
+              "target": "main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "200",
+              "particles": "false",
+              "target": "wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "100",
+              "particles": "false",
+              "target": "wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/braitenberg_controller_named_pipe.json
+++ b/xml/braitenberg_controller_named_pipe.json
@@ -1,0 +1,1171 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.40",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Braiternberg 6 inputs",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "0.00",
+                      "y": "0.00",
+                      "z": "10"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "gravitation": [
+            {
+              "x": "0.0",
+              "y": "0.0",
+              "z": "-9.81"
+            }
+          ],
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "wall 1",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 2",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Blue"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 3",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 4",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "-4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Braitenberg",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Green"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "15",
+                  "x": "2.25",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "left 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ],
+                  "ov": [
+                    {
+                      "name": "main body velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "oav": [
+                    {
+                      "name": "main body angular velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "position": [
+                    {
+                      "name": "main body position",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "NamedPipe"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "5",
+              "max": "300",
+              "particles": "false",
+              "target": "main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "200",
+              "particles": "false",
+              "target": "wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "100",
+              "particles": "false",
+              "target": "wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/braitenberg_controller_python.json
+++ b/xml/braitenberg_controller_python.json
@@ -1,0 +1,1190 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.40",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ],
+          "control": [
+            {
+              "reset": "10000"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Braiternberg 6 inputs",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "0.00",
+                      "y": "0.00",
+                      "z": "10"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "gravitation": [
+            {
+              "x": "0.0",
+              "y": "0.0",
+              "z": "-9.81"
+            }
+          ],
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "wall 1",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 2",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Blue"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 3",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 4",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "-4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Braitenberg",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Green"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "15",
+                  "x": "2.25",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "left 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ],
+                  "ov": [
+                    {
+                      "name": "main body velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "oav": [
+                    {
+                      "name": "main body angular velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "position": [
+                    {
+                      "name": "main body position",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Python",
+                  "parameter": [
+                    {
+                      "name": "debug",
+                      "value": "true"
+                    },
+                    {
+                      "name": "module",
+                      "value": "braitenberg"
+                    },
+                    {
+                      "name": "working directory",
+                      "value": "./controller"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "5",
+              "max": "300",
+              "particles": "false",
+              "target": "main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "200",
+              "particles": "false",
+              "target": "wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "100",
+              "particles": "false",
+              "target": "wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/braitenberg_controller_tcpip.json
+++ b/xml/braitenberg_controller_tcpip.json
@@ -1,0 +1,1181 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Braiternberg 6 inputs",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "0.00",
+                      "y": "0.00",
+                      "z": "10"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "gravitation": [
+            {
+              "x": "0.0",
+              "y": "0.0",
+              "z": "-9.81"
+            }
+          ],
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "wall 1",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 2",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Blue"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 3",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 4",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "-4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Braitenberg",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Green"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "15",
+                  "x": "2.25",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "left 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ],
+                  "ov": [
+                    {
+                      "name": "main body velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "oav": [
+                    {
+                      "name": "main body angular velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "position": [
+                    {
+                      "name": "main body position",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "TCPIP",
+                  "parameter": [
+                    {
+                      "name": "port",
+                      "value": "9500"
+                    },
+                    {
+                      "name": "debug",
+                      "value": "false"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "5",
+              "max": "300",
+              "particles": "false",
+              "target": "main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "200",
+              "particles": "false",
+              "target": "wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "100",
+              "particles": "false",
+              "target": "wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/braitenberg_light_source.json
+++ b/xml/braitenberg_light_source.json
@@ -1,0 +1,1262 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.40",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Braitenberg",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "0.00",
+                      "y": "0.00",
+                      "z": "10"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "gravitation": [
+            {
+              "x": "0.0",
+              "y": "0.0",
+              "z": "-9.81"
+            }
+          ],
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "wall 1",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 2",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Blue"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 3",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 4",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "-4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "pointLightSource": [
+            {
+              "brightness": "1.0",
+              "colour": "FF0000",
+              "draw": "true",
+              "name": "light source 1",
+              "size": "0.05",
+              "x": "0.0",
+              "y": "0.5",
+              "z": "0.10"
+            },
+            {
+              "brightness": "1.0",
+              "colour": "FF0000",
+              "draw": "true",
+              "name": "light source 2",
+              "size": "0.05",
+              "x": "0.0",
+              "y": "3.0",
+              "z": "0.10"
+            },
+            {
+              "brightness": "1.0",
+              "colour": "FF0000",
+              "draw": "true",
+              "name": "light source 3",
+              "size": "0.05",
+              "x": "0.0",
+              "y": "-3.0",
+              "z": "0.5"
+            },
+            {
+              "brightness": "1.0",
+              "colour": "FF0000",
+              "draw": "true",
+              "name": "light source 4",
+              "size": "0.05",
+              "x": "3.0",
+              "y": "0.0",
+              "z": "0.5"
+            },
+            {
+              "brightness": "1.0",
+              "colour": "FF0000",
+              "draw": "true",
+              "name": "light source 5",
+              "size": "0.05",
+              "x": "-3.0",
+              "y": "0.0",
+              "z": "0.5"
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Braitenberg Light Seeker",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Green"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "0.0",
+                  "x": "2.25",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "left 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "ldr": [
+                    {
+                      "name": "ldr left 2",
+                      "opening": "70",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0.045"
+                        }
+                      ],
+                      "colour": [
+                        {
+                          "value": "FF0000"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "sigma",
+                              "value": "0.4"
+                            },
+                            {
+                              "name": "mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "ldr right 2",
+                      "opening": "70",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0.045"
+                        }
+                      ],
+                      "colour": [
+                        {
+                          "value": "FF0000"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "sigma",
+                              "value": "0.4"
+                            },
+                            {
+                              "name": "mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Braitenberg2b"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "5",
+              "max": "300",
+              "particles": "false",
+              "target": "main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "200",
+              "particles": "false",
+              "target": "wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "100",
+              "particles": "false",
+              "target": "wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/braitenberg_logging.json
+++ b/xml/braitenberg_logging.json
@@ -1,0 +1,1340 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "capture": "true",
+              "follow": "false",
+              "name": "Braiternberg 6 inputs",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "0.00",
+                      "y": "0.00",
+                      "z": "10"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "gravitation": [
+            {
+              "x": "0.0",
+              "y": "0.0",
+              "z": "-9.81"
+            }
+          ],
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "wall 1",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 2",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Blue"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 3",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 4",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "-4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Braitenberg",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Green"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "35",
+                  "x": "2.25",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "left 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ],
+                  "ov": [
+                    {
+                      "name": "main body velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "position": [
+                    {
+                      "name": "main body position",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Braitenberg3b",
+                  "parameter": [
+                    {
+                      "name": "debug",
+                      "value": "true"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "5",
+              "max": "300",
+              "particles": "false",
+              "target": "main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "200",
+              "particles": "false",
+              "target": "wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "100",
+              "particles": "false",
+              "target": "wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "logging": [
+        {
+          "object": [
+            {
+              "precision": "3",
+              "target": "main body",
+              "use": [
+                {
+                  "value": "x"
+                },
+                {
+                  "value": "y"
+                }
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "wheel left",
+              "use": [
+                {
+                  "value": "x"
+                },
+                {
+                  "value": "y"
+                }
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "wheel right",
+              "use": [
+                {
+                  "value": "x"
+                },
+                {
+                  "value": "y"
+                }
+              ]
+            }
+          ],
+          "sensor": [
+            {
+              "precision": "3",
+              "target": "left 1",
+              "external": [
+                {}
+              ],
+              "internal": [
+                {}
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "left 2",
+              "external": [
+                {}
+              ],
+              "internal": [
+                {}
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "left 3",
+              "external": [
+                {}
+              ],
+              "internal": [
+                {}
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "right 3",
+              "external": [
+                {}
+              ],
+              "internal": [
+                {}
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "right 2",
+              "external": [
+                {}
+              ],
+              "internal": [
+                {}
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "right 1",
+              "external": [
+                {}
+              ],
+              "internal": [
+                {}
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "main body velocity",
+              "external": [
+                {}
+              ]
+            }
+          ],
+          "actuator": [
+            {
+              "precision": "3",
+              "target": "wheel left hinge",
+              "internal": [
+                {}
+              ],
+              "external": [
+                {}
+              ],
+              "appliedForce": [
+                {}
+              ],
+              "appliedVelocity": [
+                {}
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "wheel right hinge",
+              "internal": [
+                {}
+              ],
+              "external": [
+                {}
+              ],
+              "appliedForce": [
+                {}
+              ],
+              "appliedVelocity": [
+                {}
+              ]
+            }
+          ],
+          "console": [
+            {
+              "target": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ],
+          "csv": [
+            {
+              "name": "braitenberg",
+              "target": [
+                {
+                  "name": "main body"
+                },
+                {
+                  "name": "wheel left"
+                },
+                {
+                  "name": "wheel right"
+                },
+                {
+                  "name": "right 1"
+                },
+                {
+                  "name": "wheel left hinge"
+                },
+                {
+                  "name": "wheel right hinge"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/braitenberg_nocontroller.json
+++ b/xml/braitenberg_nocontroller.json
@@ -1,0 +1,1112 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Braiternberg",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "0.00",
+                      "y": "0.00",
+                      "z": "10"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "wall 1",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 2",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Blue"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 3",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 4",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "-4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Braitenberg",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Green"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "15",
+                  "x": "2.25",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "left 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "5",
+              "max": "300",
+              "particles": "false",
+              "target": "main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "200",
+              "particles": "false",
+              "target": "wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "100",
+              "particles": "false",
+              "target": "wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/braitenberg_noise.json
+++ b/xml/braitenberg_noise.json
@@ -1,0 +1,1477 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.40",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Braiternberg 6 inputs",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "0.00",
+                      "y": "0.00",
+                      "z": "10"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "gravitation": [
+            {
+              "x": "0.0",
+              "y": "0.0",
+              "z": "-9.81"
+            }
+          ],
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "wall 1",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 2",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Blue"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 3",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 4",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "-4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Braitenberg",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Green"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "15",
+                  "x": "2.25",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "sigma",
+                              "value": "0.2"
+                            },
+                            {
+                              "name": "mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "sigma",
+                              "value": "0.2"
+                            },
+                            {
+                              "name": "mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "left 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "sigma",
+                              "value": "0.2"
+                            },
+                            {
+                              "name": "mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "sigma",
+                              "value": "0.2"
+                            },
+                            {
+                              "name": "mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "sigma",
+                              "value": "0.2"
+                            },
+                            {
+                              "name": "mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "sigma",
+                              "value": "0.2"
+                            },
+                            {
+                              "name": "mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "sigma",
+                              "value": "0.2"
+                            },
+                            {
+                              "name": "mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "sigma",
+                              "value": "0.2"
+                            },
+                            {
+                              "name": "mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "sigma",
+                              "value": "0.2"
+                            },
+                            {
+                              "name": "mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "sigma",
+                              "value": "0.2"
+                            },
+                            {
+                              "name": "mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "ov": [
+                    {
+                      "name": "main body velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "oav": [
+                    {
+                      "name": "main body angular velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "position": [
+                    {
+                      "name": "main body position",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Braitenberg2b",
+                  "parameter": [
+                    {
+                      "name": "debug",
+                      "value": "true"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "5",
+              "max": "300",
+              "particles": "false",
+              "target": "main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "200",
+              "particles": "false",
+              "target": "wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "100",
+              "particles": "false",
+              "target": "wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "logging": [
+        {
+          "sensor": [
+            {
+              "precision": "3",
+              "target": "left 1",
+              "external": [
+                {}
+              ],
+              "internal": [
+                {}
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "left 2",
+              "external": [
+                {}
+              ],
+              "internal": [
+                {}
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "left 3",
+              "external": [
+                {}
+              ],
+              "internal": [
+                {}
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "right 3",
+              "external": [
+                {}
+              ],
+              "internal": [
+                {}
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "right 2",
+              "external": [
+                {}
+              ],
+              "internal": [
+                {}
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "right 1",
+              "external": [
+                {}
+              ],
+              "internal": [
+                {}
+              ]
+            }
+          ],
+          "actuator": [
+            {
+              "precision": "3",
+              "target": "wheel left hinge",
+              "external": [
+                {}
+              ],
+              "internal": [
+                {}
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "wheel right hinge",
+              "external": [
+                {}
+              ],
+              "internal": [
+                {}
+              ]
+            }
+          ],
+          "console": [
+            {
+              "target": [
+                {
+                  "name": "left 1"
+                },
+                {
+                  "name": "left 2"
+                },
+                {
+                  "name": "left 3"
+                },
+                {
+                  "name": "right 3"
+                },
+                {
+                  "name": "right 2"
+                },
+                {
+                  "name": "right 1"
+                },
+                {
+                  "name": "wheel left hinge"
+                },
+                {
+                  "name": "wheel right hinge"
+                }
+              ]
+            }
+          ],
+          "gnuplot": [
+            {
+              "delay": "100",
+              "size": "1000",
+              "target": [
+                {
+                  "name": "left 1"
+                },
+                {
+                  "name": "left 2"
+                },
+                {
+                  "name": "left 3"
+                },
+                {
+                  "name": "right 3"
+                },
+                {
+                  "name": "right 2"
+                },
+                {
+                  "name": "right 1"
+                },
+                {
+                  "name": "wheel left"
+                },
+                {
+                  "name": "wheel right"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/braitenberg_trace_projection.json
+++ b/xml/braitenberg_trace_projection.json
@@ -1,0 +1,1131 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.40",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Braiternberg",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "0.00",
+                      "y": "0.00",
+                      "z": "10"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "wall 1",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 2",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Blue"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 3",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 4",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "-4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Braitenberg",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Green"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "15",
+                  "x": "2.25",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "left 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "left 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 3",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 2",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right 1",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Braitenberg2b"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "5",
+              "max": "300",
+              "particles": "false",
+              "project": "xz",
+              "target": "main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "200",
+              "particles": "false",
+              "project": "yz",
+              "target": "wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "x": "1.0"
+                }
+              ]
+            },
+            {
+              "length": "5",
+              "max": "100",
+              "particles": "false",
+              "project": "xy",
+              "target": "wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "z": "0.1"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/braitenberg_zoo.json
+++ b/xml/braitenberg_zoo.json
@@ -1,0 +1,3637 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.40",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Braitenberg",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "0.00",
+                      "y": "0.00",
+                      "z": "10"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "gravitation": [
+            {
+              "x": "0.0",
+              "y": "0.0",
+              "z": "-9.81"
+            }
+          ],
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "wall 1",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 2",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "7.75"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-4",
+                  "y": "0",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Blue"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 3",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Green"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "wall 4",
+              "dimension": [
+                {
+                  "depth": "0.25",
+                  "height": "0.5",
+                  "width": "8.25"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "0",
+                  "x": "0",
+                  "y": "-4",
+                  "z": "-0.15"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "YARS/Wall2"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "YARS/Wall1"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "pointLightSource": [
+            {
+              "brightness": "1.0",
+              "colour": "FF0000",
+              "draw": "true",
+              "name": "light source 1",
+              "size": "0.05",
+              "x": "0.0",
+              "y": "0.5",
+              "z": "0.10"
+            },
+            {
+              "brightness": "1.0",
+              "colour": "FF0000",
+              "draw": "true",
+              "name": "light source 2",
+              "size": "0.05",
+              "x": "0.0",
+              "y": "3.0",
+              "z": "0.10"
+            },
+            {
+              "brightness": "1.0",
+              "colour": "FF0000",
+              "draw": "true",
+              "name": "light source 3",
+              "size": "0.05",
+              "x": "0.0",
+              "y": "-3.0",
+              "z": "0.5"
+            },
+            {
+              "brightness": "1.0",
+              "colour": "FF0000",
+              "draw": "true",
+              "name": "light source 4",
+              "size": "0.05",
+              "x": "3.0",
+              "y": "0.0",
+              "z": "0.5"
+            },
+            {
+              "brightness": "1.0",
+              "colour": "FF0000",
+              "draw": "true",
+              "name": "light source 5",
+              "size": "0.05",
+              "x": "-3.0",
+              "y": "0.0",
+              "z": "0.5"
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Braitenberg 2a",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "2a main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Purple"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Purple"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Purple"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "2a wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "2a wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "2a wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2a wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "180.0",
+                  "x": "-2.25",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "2a wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "2a wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "2a main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "2a wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "2a wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "2a main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "2a left 1",
+                      "object": [
+                        {
+                          "name": "2a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2a left 2",
+                      "object": [
+                        {
+                          "name": "2a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2a left 3",
+                      "object": [
+                        {
+                          "name": "2a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2a right 3",
+                      "object": [
+                        {
+                          "name": "2a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2a right 2",
+                      "object": [
+                        {
+                          "name": "2a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2a right 1",
+                      "object": [
+                        {
+                          "name": "2a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "ldr": [
+                    {
+                      "name": "2a ldr left 2",
+                      "opening": "70",
+                      "object": [
+                        {
+                          "name": "2a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0.045"
+                        }
+                      ],
+                      "colour": [
+                        {
+                          "value": "FF0000"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "2a sigma",
+                              "value": "0.4"
+                            },
+                            {
+                              "name": "2a mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2a ldr right 2",
+                      "opening": "70",
+                      "object": [
+                        {
+                          "name": "2a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0.045"
+                        }
+                      ],
+                      "colour": [
+                        {
+                          "value": "FF0000"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "2a sigma",
+                              "value": "0.4"
+                            },
+                            {
+                              "name": "2a mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "2a left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "2a wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2a right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "2a wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Braitenberg2a",
+                  "parameter": [
+                    {
+                      "name": "osd",
+                      "value": "false"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Braitenberg 2b",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "2b main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Green"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Green"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "2b wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "2b wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "2b wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2b wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "0.0",
+                  "x": "0.0",
+                  "y": "2.0",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "2b wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "2b wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "2b main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "2b wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "2b wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "2b main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "2b left 1",
+                      "object": [
+                        {
+                          "name": "2b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2b left 2",
+                      "object": [
+                        {
+                          "name": "2b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2b left 3",
+                      "object": [
+                        {
+                          "name": "2b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2b right 3",
+                      "object": [
+                        {
+                          "name": "2b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2b right 2",
+                      "object": [
+                        {
+                          "name": "2b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2b right 1",
+                      "object": [
+                        {
+                          "name": "2b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "ldr": [
+                    {
+                      "name": "2b ldr left 2",
+                      "opening": "70",
+                      "object": [
+                        {
+                          "name": "2b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0.045"
+                        }
+                      ],
+                      "colour": [
+                        {
+                          "value": "FF0000"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "2b sigma",
+                              "value": "0.4"
+                            },
+                            {
+                              "name": "2b mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2b ldr right 2",
+                      "opening": "70",
+                      "object": [
+                        {
+                          "name": "2b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0.045"
+                        }
+                      ],
+                      "colour": [
+                        {
+                          "value": "FF0000"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "2b sigma",
+                              "value": "0.4"
+                            },
+                            {
+                              "name": "2b mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "2b left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "2b wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "2b right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "2b wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Braitenberg2b",
+                  "parameter": [
+                    {
+                      "name": "osd",
+                      "value": "false"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Braitenberg 3a",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "3a main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Blue"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Blue"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Blue"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "3a wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "3a wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "3a wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3a wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "0.0",
+                  "x": "0.0",
+                  "y": "-2.0",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "3a wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "3a wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "3a main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "3a wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "3a wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "3a main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "3a left 1",
+                      "object": [
+                        {
+                          "name": "3a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3a left 2",
+                      "object": [
+                        {
+                          "name": "3a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3a left 3",
+                      "object": [
+                        {
+                          "name": "3a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3a right 3",
+                      "object": [
+                        {
+                          "name": "3a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3a right 2",
+                      "object": [
+                        {
+                          "name": "3a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3a right 1",
+                      "object": [
+                        {
+                          "name": "3a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "ldr": [
+                    {
+                      "name": "3a ldr left 2",
+                      "opening": "70",
+                      "object": [
+                        {
+                          "name": "3a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0.045"
+                        }
+                      ],
+                      "colour": [
+                        {
+                          "value": "FF0000"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "3a sigma",
+                              "value": "0.4"
+                            },
+                            {
+                              "name": "3a mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3a ldr right 2",
+                      "opening": "70",
+                      "object": [
+                        {
+                          "name": "3a main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0.045"
+                        }
+                      ],
+                      "colour": [
+                        {
+                          "value": "FF0000"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "3a sigma",
+                              "value": "0.4"
+                            },
+                            {
+                              "name": "3a mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "3a left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "3a wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3a right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "3a wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Braitenberg3a",
+                  "parameter": [
+                    {
+                      "name": "osd",
+                      "value": "false"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Braitenberg 3b",
+              "body": [
+                {
+                  "composite": [
+                    {
+                      "name": "composite",
+                      "geometry": [
+                        {
+                          "cylinder": [
+                            {
+                              "name": "3b main body",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "height": "0.09",
+                                  "radius": "0.10"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0",
+                                  "y": "0",
+                                  "z": "0.01"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "top": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Yellow"
+                                    }
+                                  ],
+                                  "bottom": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Yellow"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "name": "Chain/Circuit/Body/Yellow"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "1.0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "sphere": [
+                            {
+                              "name": "3b wheel front",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "0.08",
+                                  "y": "0",
+                                  "z": "-0.0499999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "3b wheel back",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.01"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "alpha": "0",
+                                  "beta": "0",
+                                  "gamma": "0",
+                                  "x": "-0.08",
+                                  "y": "0",
+                                  "z": "-0.049999"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Wheel"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "sphere": [
+                    {
+                      "name": "3b wheel left",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3b wheel right",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.03"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "-0.085",
+                          "z": "-0.03"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Wheel"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1000"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "gamma": "0.0",
+                  "x": "2.25",
+                  "z": "0.05"
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "3b wheel left hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "3b wheel left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "3b main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "3b wheel right hinge",
+                      "type": "velocity",
+                      "source": [
+                        {
+                          "name": "3b wheel right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "3b main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "10.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90.0",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.001",
+                          "i": "0.001",
+                          "p": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "proximity": [
+                    {
+                      "name": "3b left 1",
+                      "object": [
+                        {
+                          "name": "3b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3b left 2",
+                      "object": [
+                        {
+                          "name": "3b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3b left 3",
+                      "object": [
+                        {
+                          "name": "3b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3b right 3",
+                      "object": [
+                        {
+                          "name": "3b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "15",
+                          "beta": "90",
+                          "x": "0.0965926",
+                          "y": "-0.0258819",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3b right 2",
+                      "object": [
+                        {
+                          "name": "3b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3b right 1",
+                      "object": [
+                        {
+                          "name": "3b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "-0.1",
+                          "z": "0"
+                        }
+                      ],
+                      "distance": [
+                        {
+                          "meter": "0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "openingAngles": [
+                        {
+                          "x": "25",
+                          "y": "2.5"
+                        }
+                      ]
+                    }
+                  ],
+                  "ldr": [
+                    {
+                      "name": "3b ldr left 2",
+                      "opening": "70",
+                      "object": [
+                        {
+                          "name": "3b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "-45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "0.0707107",
+                          "z": "0.045"
+                        }
+                      ],
+                      "colour": [
+                        {
+                          "value": "FF0000"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "3b sigma",
+                              "value": "0.4"
+                            },
+                            {
+                              "name": "3b mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3b ldr right 2",
+                      "opening": "70",
+                      "object": [
+                        {
+                          "name": "3b main body"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "45",
+                          "beta": "90",
+                          "x": "0.0707107",
+                          "y": "-0.0707107",
+                          "z": "0.045"
+                        }
+                      ],
+                      "colour": [
+                        {
+                          "value": "FF0000"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "noise": [
+                        {
+                          "module": "white",
+                          "parameter": [
+                            {
+                              "name": "3b sigma",
+                              "value": "0.4"
+                            },
+                            {
+                              "name": "3b mean",
+                              "value": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "velocity": [
+                    {
+                      "name": "3b left wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "3b wheel left hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "3b right wheel hinge sensor",
+                      "object": [
+                        {
+                          "name": "3b wheel right hinge"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10",
+                          "min": "-10"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Braitenberg3b",
+                  "parameter": [
+                    {
+                      "name": "osd",
+                      "value": "false"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "20",
+              "max": "300",
+              "particles": "false",
+              "target": "2a main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "20",
+              "max": "200",
+              "particles": "false",
+              "target": "2a wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "20",
+              "max": "100",
+              "particles": "false",
+              "target": "2a wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "20",
+              "max": "300",
+              "particles": "false",
+              "target": "2b main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "20",
+              "max": "200",
+              "particles": "false",
+              "target": "2b wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "20",
+              "max": "100",
+              "particles": "false",
+              "target": "2b wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "20",
+              "max": "300",
+              "particles": "false",
+              "target": "3a main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "20",
+              "max": "200",
+              "particles": "false",
+              "target": "3a wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "20",
+              "max": "100",
+              "particles": "false",
+              "target": "3a wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "20",
+              "max": "300",
+              "particles": "false",
+              "target": "3b main body",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "ff0000",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "ff000000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "20",
+              "max": "200",
+              "particles": "false",
+              "target": "3b wheel right",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "00ff00",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00ff0000",
+                  "size": "0.00"
+                }
+              ]
+            },
+            {
+              "length": "20",
+              "max": "100",
+              "particles": "false",
+              "target": "3b wheel left",
+              "time": "5",
+              "init": [
+                {
+                  "colour": "0000ff",
+                  "size": "0.01"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000ff00",
+                  "size": "0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/falling_objects.json
+++ b/xml/falling_objects.json
@@ -1,0 +1,326 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "1000",
+          "solver": [
+            {
+              "iterations": "100"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Falling Object",
+              "show": "true",
+              "size": [
+                {
+                  "height": "600",
+                  "width": "600"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "3.00",
+                      "y": "0.00",
+                      "z": "2.0"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.00",
+                      "z": "1.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "swinging body"
+                }
+              ]
+            }
+          ],
+          "visualise": [
+            {
+              "joints": [
+                {
+                  "height": "0.5",
+                  "radius": "0.01"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Muscle",
+              "body": [
+                {
+                  "sphere": [
+                    {
+                      "name": "source body",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.10"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "y": "0.0",
+                          "z": "2.00"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Circuit/Top/Green"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "destination body",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.10"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.5",
+                          "y": "0.5",
+                          "z": "1.5"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Circuit/Top/Green"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actuators": [
+                {
+                  "slider": [
+                    {
+                      "mode": "passive",
+                      "name": "slider",
+                      "type": "positional",
+                      "source": [
+                        {
+                          "name": "source body"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "destination body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "2.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "-0.1"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "0.5",
+                          "min": "-0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "0"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/hexaboard.json
+++ b/xml/hexaboard.json
@@ -1,0 +1,2438 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "100"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "capture": "false",
+              "follow": "true",
+              "name": "main",
+              "show": "true",
+              "resolution": [
+                {
+                  "name": "720p"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "7.00",
+                      "y": "0.00",
+                      "z": "2.0"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.0",
+                      "z": "1.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "800040",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "-0.0",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.25"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.25"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.000",
+                      "i": "0.0000",
+                      "p": "0.0"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.00"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "name": "env",
+          "ground": [
+            {
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGround"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "hexapod",
+              "body": [
+                {
+                  "selfCollide": "true",
+                  "ply": [
+                    {
+                      "convex": "false",
+                      "filename": "ply/main_body.ply",
+                      "name": "main body",
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.449429"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "MainBodyMesh.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "50"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_right.ply",
+                      "name": "rear right femur",
+                      "pose": [
+                        {
+                          "x": "0.700179",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearFemurMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_right.ply",
+                      "name": "rear right tibia",
+                      "pose": [
+                        {
+                          "x": "1.080657",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTibiaMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_right.ply",
+                      "name": "rear right tarsus",
+                      "pose": [
+                        {
+                          "x": "1.613118",
+                          "y": "-2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTarsusMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_right.ply",
+                      "name": "centre right femur",
+                      "pose": [
+                        {
+                          "x": "0.700179",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreFemurMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_right.ply",
+                      "name": "centre right tibia",
+                      "pose": [
+                        {
+                          "x": "1.080657",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTibiaMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_right.ply",
+                      "name": "centre right tarsus",
+                      "pose": [
+                        {
+                          "x": "1.613118",
+                          "y": "0.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTarsusMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_right.ply",
+                      "name": "front right femur",
+                      "pose": [
+                        {
+                          "x": "0.700179",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontFemurMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_right.ply",
+                      "name": "front right tibia",
+                      "pose": [
+                        {
+                          "x": "1.080657",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTibiaMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_right.ply",
+                      "name": "front right tarsus",
+                      "pose": [
+                        {
+                          "x": "1.613118",
+                          "y": "2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTarsusMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_left.ply",
+                      "name": "rear left femur",
+                      "pose": [
+                        {
+                          "x": "-0.700179",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearFemurMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_left.ply",
+                      "name": "rear left tibia",
+                      "pose": [
+                        {
+                          "x": "-1.080657",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTibiaMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_left.ply",
+                      "name": "rear left tarsus",
+                      "pose": [
+                        {
+                          "x": "-1.613118",
+                          "y": "-2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTarsusMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_left.ply",
+                      "name": "centre left femur",
+                      "pose": [
+                        {
+                          "x": "-0.700179",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreFemurMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_left.ply",
+                      "name": "centre left tibia",
+                      "pose": [
+                        {
+                          "x": "-1.080657",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTibiaMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_left.ply",
+                      "name": "centre left tarsus",
+                      "pose": [
+                        {
+                          "x": "-1.613118",
+                          "y": "0.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTarsusMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_left.ply",
+                      "name": "front left femur",
+                      "pose": [
+                        {
+                          "x": "-0.700179",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontFemurMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_left.ply",
+                      "name": "front left tibia",
+                      "pose": [
+                        {
+                          "x": "-1.080657",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTibiaMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_left.ply",
+                      "name": "front left tarsus",
+                      "pose": [
+                        {
+                          "x": "-1.613118",
+                          "y": "2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTarsusMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "front right z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90",
+                          "x": "-0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "front right y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front right tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "front left z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "-90",
+                          "x": "0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "front left y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front left tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-90",
+                          "x": "-0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre right z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90",
+                          "x": "-0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre right y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre right tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre left z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "-90",
+                          "x": "0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre left y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre left tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-90",
+                          "x": "-0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear right z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90",
+                          "x": "-0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear right y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear right tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear left z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "-90",
+                          "x": "0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear left y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear left tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-90",
+                          "x": "-0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    }
+                  ],
+                  "fixed": [
+                    {
+                      "name": "front left ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "front left tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front left tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre left ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "centre left tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre left tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear left ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "rear left tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear left tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "front right ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "front right tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front right tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre right ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "centre right tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre right tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear right ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "rear right tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear right tarsus"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "#children": [
+                    {
+                      "#tag": "deflection",
+                      "name": "front right z-axis sensor",
+                      "object": [
+                        {
+                          "name": "front right z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "front right y-axis sensor",
+                      "object": [
+                        {
+                          "name": "front right y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "front right tarsus contact",
+                      "object": [
+                        {
+                          "name": "front right tarsus"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "front left z-axis sensor",
+                      "object": [
+                        {
+                          "name": "front left z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "front left y-axis sensor",
+                      "object": [
+                        {
+                          "name": "front left y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "front left tarsus contact",
+                      "object": [
+                        {
+                          "name": "front left tarsus"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "centre right z-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre right z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "centre right y-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre right y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "centre right tarsus contact",
+                      "object": [
+                        {
+                          "name": "centre right tarsus"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "centre left z-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre left z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "centre left y-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre left y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "centre left tarsus contact",
+                      "object": [
+                        {
+                          "name": "centre left tarsus"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "rear right z-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear right z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "rear right y-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear right y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "rear right tarsus contact",
+                      "object": [
+                        {
+                          "name": "rear right tarsus"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "rear left z-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear left z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "rear left y-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear left y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "rear left tarsus contact",
+                      "object": [
+                        {
+                          "name": "rear left tarsus"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "position",
+                      "name": "xyz position main",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "orientation",
+                      "name": "xyz orientation main",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "main body",
+              "time": "60",
+              "init": [
+                {
+                  "colour": "FF0000",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "FF000000",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front left femur",
+              "time": "60",
+              "init": [
+                {
+                  "colour": "00FF00",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "00FF0000",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front left tarsus",
+              "time": "60",
+              "init": [
+                {
+                  "colour": "0000FF",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "0000FF00",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front right femur",
+              "time": "60",
+              "init": [
+                {
+                  "colour": "F0FF00",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "F0FF0000",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front right tarsus",
+              "time": "60",
+              "init": [
+                {
+                  "colour": "F000FF",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "F000FF00",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/hexapod.json
+++ b/xml/hexapod.json
@@ -1,0 +1,2369 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "100"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "capture": "false",
+              "follow": "true",
+              "name": "main",
+              "show": "true",
+              "resolution": [
+                {
+                  "name": "720p"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "7.00",
+                      "y": "0.00",
+                      "z": "2.0"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.0",
+                      "z": "1.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "800040",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "-0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.25"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.25"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.000",
+                      "i": "0.0000",
+                      "p": "0.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.50"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.50"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.00"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "name": "env",
+          "ground": [
+            {
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGround"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "hexapod",
+              "body": [
+                {
+                  "selfCollide": "true",
+                  "ply": [
+                    {
+                      "convex": "false",
+                      "filename": "ply/main_body.ply",
+                      "name": "main body",
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.449429"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "MainBodyMesh.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "50"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_right.ply",
+                      "name": "rear right femur",
+                      "pose": [
+                        {
+                          "x": "0.700179",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearFemurMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_right.ply",
+                      "name": "rear right tibia",
+                      "pose": [
+                        {
+                          "x": "1.080657",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTibiaMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_right.ply",
+                      "name": "rear right tarsus",
+                      "pose": [
+                        {
+                          "x": "1.613118",
+                          "y": "-2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTarsusMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_right.ply",
+                      "name": "centre right femur",
+                      "pose": [
+                        {
+                          "x": "0.700179",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreFemurMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_right.ply",
+                      "name": "centre right tibia",
+                      "pose": [
+                        {
+                          "x": "1.080657",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTibiaMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_right.ply",
+                      "name": "centre right tarsus",
+                      "pose": [
+                        {
+                          "x": "1.613118",
+                          "y": "0.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTarsusMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_right.ply",
+                      "name": "front right femur",
+                      "pose": [
+                        {
+                          "x": "0.700179",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontFemurMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_right.ply",
+                      "name": "front right tibia",
+                      "pose": [
+                        {
+                          "x": "1.080657",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTibiaMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_right.ply",
+                      "name": "front right tarsus",
+                      "pose": [
+                        {
+                          "x": "1.613118",
+                          "y": "2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTarsusMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_left.ply",
+                      "name": "rear left femur",
+                      "pose": [
+                        {
+                          "x": "-0.700179",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearFemurMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_left.ply",
+                      "name": "rear left tibia",
+                      "pose": [
+                        {
+                          "x": "-1.080657",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTibiaMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_left.ply",
+                      "name": "rear left tarsus",
+                      "pose": [
+                        {
+                          "x": "-1.613118",
+                          "y": "-2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTarsusMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_left.ply",
+                      "name": "centre left femur",
+                      "pose": [
+                        {
+                          "x": "-0.700179",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreFemurMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_left.ply",
+                      "name": "centre left tibia",
+                      "pose": [
+                        {
+                          "x": "-1.080657",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTibiaMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_left.ply",
+                      "name": "centre left tarsus",
+                      "pose": [
+                        {
+                          "x": "-1.613118",
+                          "y": "0.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTarsusMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_left.ply",
+                      "name": "front left femur",
+                      "pose": [
+                        {
+                          "x": "-0.700179",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontFemurMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_left.ply",
+                      "name": "front left tibia",
+                      "pose": [
+                        {
+                          "x": "-1.080657",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTibiaMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_left.ply",
+                      "name": "front left tarsus",
+                      "pose": [
+                        {
+                          "x": "-1.613118",
+                          "y": "2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTarsusMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "front right z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90",
+                          "x": "-0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "front right y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front right tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "front left z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "-90",
+                          "x": "0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "front left y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front left tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-90",
+                          "x": "-0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre right z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90",
+                          "x": "-0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre right y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre right tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre left z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "-90",
+                          "x": "0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre left y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre left tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-90",
+                          "x": "-0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear right z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90",
+                          "x": "-0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear right y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear right tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear left z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "-90",
+                          "x": "0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear left y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear left tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-90",
+                          "x": "-0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    }
+                  ],
+                  "fixed": [
+                    {
+                      "name": "front left ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "front left tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front left tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre left ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "centre left tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre left tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear left ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "rear left tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear left tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "front right ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "front right tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front right tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre right ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "centre right tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre right tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear right ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "rear right tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear right tarsus"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "deflection": [
+                    {
+                      "name": "front right z-axis sensor",
+                      "object": [
+                        {
+                          "name": "front right z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "front right y-axis sensor",
+                      "object": [
+                        {
+                          "name": "front right y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "front left z-axis sensor",
+                      "object": [
+                        {
+                          "name": "front left z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "front left y-axis sensor",
+                      "object": [
+                        {
+                          "name": "front left y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre right z-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre right z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre right y-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre right y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre left z-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre left z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre left y-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre left y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear right z-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear right z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear right y-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear right y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear left z-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear left z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear left y-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear left y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ],
+                  "position": [
+                    {
+                      "name": "main body position",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "ov": [
+                    {
+                      "name": "main body velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Python",
+                  "parameter": [
+                    {
+                      "name": "module",
+                      "value": "hexapod"
+                    },
+                    {
+                      "name": "working directory",
+                      "value": "/Volumes/Eregion/projects/yars/contrib/controller"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "project": "xy",
+              "target": "main body",
+              "time": "20",
+              "init": [
+                {
+                  "colour": "009cff",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "009cff00",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.05"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front left femur",
+              "time": "20",
+              "init": [
+                {
+                  "colour": "95aeca",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "95aeca00",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front left tarsus",
+              "time": "20",
+              "init": [
+                {
+                  "colour": "668092",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "66809200",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front right femur",
+              "time": "20",
+              "init": [
+                {
+                  "colour": "95aeca",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "95aeca00",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front right tarsus",
+              "time": "20",
+              "init": [
+                {
+                  "colour": "668092",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "66809200",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/hexapod_crbm.json
+++ b/xml/hexapod_crbm.json
@@ -1,0 +1,2639 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "100"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "capture": "false",
+              "follow": "true",
+              "name": "main",
+              "show": "true",
+              "resolution": [
+                {
+                  "name": "720p"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "7.00",
+                      "y": "0.00",
+                      "z": "2.0"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.0",
+                      "z": "1.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "800040",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "-0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.25"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.25"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.000",
+                      "i": "0.0000",
+                      "p": "0.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.50"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.50"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.00"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "name": "env",
+          "ground": [
+            {
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGround"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "hexapod",
+              "body": [
+                {
+                  "selfCollide": "true",
+                  "ply": [
+                    {
+                      "convex": "false",
+                      "filename": "ply/main_body.ply",
+                      "name": "main body",
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.449429"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "MainBodyMesh.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "50"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_right.ply",
+                      "name": "rear right femur",
+                      "pose": [
+                        {
+                          "x": "0.700179",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearFemurMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_right.ply",
+                      "name": "rear right tibia",
+                      "pose": [
+                        {
+                          "x": "1.080657",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTibiaMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_right.ply",
+                      "name": "rear right tarsus",
+                      "pose": [
+                        {
+                          "x": "1.613118",
+                          "y": "-2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTarsusMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_right.ply",
+                      "name": "centre right femur",
+                      "pose": [
+                        {
+                          "x": "0.700179",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreFemurMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_right.ply",
+                      "name": "centre right tibia",
+                      "pose": [
+                        {
+                          "x": "1.080657",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTibiaMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_right.ply",
+                      "name": "centre right tarsus",
+                      "pose": [
+                        {
+                          "x": "1.613118",
+                          "y": "0.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTarsusMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_right.ply",
+                      "name": "front right femur",
+                      "pose": [
+                        {
+                          "x": "0.700179",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontFemurMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_right.ply",
+                      "name": "front right tibia",
+                      "pose": [
+                        {
+                          "x": "1.080657",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTibiaMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_right.ply",
+                      "name": "front right tarsus",
+                      "pose": [
+                        {
+                          "x": "1.613118",
+                          "y": "2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTarsusMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_left.ply",
+                      "name": "rear left femur",
+                      "pose": [
+                        {
+                          "x": "-0.700179",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearFemurMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_left.ply",
+                      "name": "rear left tibia",
+                      "pose": [
+                        {
+                          "x": "-1.080657",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTibiaMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_left.ply",
+                      "name": "rear left tarsus",
+                      "pose": [
+                        {
+                          "x": "-1.613118",
+                          "y": "-2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTarsusMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_left.ply",
+                      "name": "centre left femur",
+                      "pose": [
+                        {
+                          "x": "-0.700179",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreFemurMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_left.ply",
+                      "name": "centre left tibia",
+                      "pose": [
+                        {
+                          "x": "-1.080657",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTibiaMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_left.ply",
+                      "name": "centre left tarsus",
+                      "pose": [
+                        {
+                          "x": "-1.613118",
+                          "y": "0.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTarsusMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_left.ply",
+                      "name": "front left femur",
+                      "pose": [
+                        {
+                          "x": "-0.700179",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontFemurMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_left.ply",
+                      "name": "front left tibia",
+                      "pose": [
+                        {
+                          "x": "-1.080657",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTibiaMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_left.ply",
+                      "name": "front left tarsus",
+                      "pose": [
+                        {
+                          "x": "-1.613118",
+                          "y": "2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTarsusMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "front right z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90",
+                          "x": "-0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "front right y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front right tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "front left z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "-90",
+                          "x": "0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "front left y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front left tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-90",
+                          "x": "-0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre right z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90",
+                          "x": "-0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre right y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre right tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre left z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "-90",
+                          "x": "0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre left y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre left tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-90",
+                          "x": "-0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear right z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90",
+                          "x": "-0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear right y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear right tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear left z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "-90",
+                          "x": "0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear left y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear left tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-90",
+                          "x": "-0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    }
+                  ],
+                  "fixed": [
+                    {
+                      "name": "front left ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "front left tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front left tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre left ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "centre left tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre left tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear left ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "rear left tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear left tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "front right ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "front right tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front right tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre right ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "centre right tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre right tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear right ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "rear right tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear right tarsus"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "deflection": [
+                    {
+                      "name": "front right z-axis sensor",
+                      "object": [
+                        {
+                          "name": "front right z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "front right y-axis sensor",
+                      "object": [
+                        {
+                          "name": "front right y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "front left z-axis sensor",
+                      "object": [
+                        {
+                          "name": "front left z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "front left y-axis sensor",
+                      "object": [
+                        {
+                          "name": "front left y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre right z-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre right z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre right y-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre right y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre left z-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre left z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre left y-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre left y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear right z-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear right z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear right y-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear right y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear left z-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear left z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear left y-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear left y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ],
+                  "position": [
+                    {
+                      "name": "main body position",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "ov": [
+                    {
+                      "name": "main body velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "CRBMCtrl",
+                  "parameter": [
+                    {
+                      "name": "crbm",
+                      "value": "/Users/zahedi/projects/YARS/contrib/controller/mode_four.rbm"
+                    },
+                    {
+                      "name": "A",
+                      "value": "/Users/zahedi/projects/YARS/contrib/controller/actuators.csv"
+                    },
+                    {
+                      "name": "init",
+                      "value": "20"
+                    },
+                    {
+                      "name": "record",
+                      "value": "false"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "project": "xy",
+              "target": "main body",
+              "time": "20",
+              "init": [
+                {
+                  "colour": "009cff",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "009cff00",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.05"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front left femur",
+              "time": "20",
+              "init": [
+                {
+                  "colour": "95aeca",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "95aeca00",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front left tarsus",
+              "time": "20",
+              "init": [
+                {
+                  "colour": "668092",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "66809200",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front right femur",
+              "time": "20",
+              "init": [
+                {
+                  "colour": "95aeca",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "95aeca00",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front right tarsus",
+              "time": "20",
+              "init": [
+                {
+                  "colour": "668092",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "66809200",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "logging": [
+        {
+          "sensor": [
+            {
+              "precision": "8",
+              "target": "front right z-axis sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "front right y-axis sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "front left z-axis sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "front left y-axis sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "centre right z-axis sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "centre right y-axis sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "centre left z-axis sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "centre left y-axis sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "rear right z-axis sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "rear right y-axis sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "rear left z-axis sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "rear left y-axis sensor",
+              "external": [
+                {}
+              ]
+            }
+          ],
+          "actuator": [
+            {
+              "precision": "8",
+              "target": "front right z-axis",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "front right y-axis",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "front left z-axis",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "front left y-axis",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "centre right z-axis",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "centre right y-axis",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "centre left z-axis",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "centre left y-axis",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "rear right z-axis",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "rear right y-axis",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "rear left z-axis",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "precision": "8",
+              "target": "rear left y-axis",
+              "external": [
+                {}
+              ]
+            }
+          ],
+          "csv": [
+            {
+              "date": "false",
+              "name": "sensors",
+              "target": [
+                {
+                  "name": "front right z-axis sensor"
+                },
+                {
+                  "name": "front right y-axis sensor"
+                },
+                {
+                  "name": "front left z-axis sensor"
+                },
+                {
+                  "name": "front left y-axis sensor"
+                },
+                {
+                  "name": "centre right z-axis sensor"
+                },
+                {
+                  "name": "centre right y-axis sensor"
+                },
+                {
+                  "name": "centre left z-axis sensor"
+                },
+                {
+                  "name": "centre left y-axis sensor"
+                },
+                {
+                  "name": "rear right z-axis sensor"
+                },
+                {
+                  "name": "rear right y-axis sensor"
+                },
+                {
+                  "name": "rear left z-axis sensor"
+                },
+                {
+                  "name": "rear left y-axis sensor"
+                }
+              ]
+            },
+            {
+              "date": "false",
+              "name": "actuators",
+              "target": [
+                {
+                  "name": "front right z-axis"
+                },
+                {
+                  "name": "front right y-axis"
+                },
+                {
+                  "name": "front left z-axis"
+                },
+                {
+                  "name": "front left y-axis"
+                },
+                {
+                  "name": "centre right z-axis"
+                },
+                {
+                  "name": "centre right y-axis"
+                },
+                {
+                  "name": "centre left z-axis"
+                },
+                {
+                  "name": "centre left y-axis"
+                },
+                {
+                  "name": "rear right z-axis"
+                },
+                {
+                  "name": "rear right y-axis"
+                },
+                {
+                  "name": "rear left z-axis"
+                },
+                {
+                  "name": "rear left y-axis"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/hexapod_logging.json
+++ b/xml/hexapod_logging.json
@@ -1,0 +1,3294 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "200"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "capture": "false",
+              "follow": "true",
+              "name": "main",
+              "show": "false",
+              "resolution": [
+                {
+                  "name": "720p"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "7.00",
+                      "y": "0.00",
+                      "z": "3.5"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.0",
+                      "z": "1.5"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "800000",
+                      "font": "Time",
+                      "size": "24"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "800000",
+                      "font": "Robot",
+                      "size": "24"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.0"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "name": "env",
+          "ground": [
+            {
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGround"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "obstacle",
+              "dimension": [
+                {
+                  "depth": "0.15",
+                  "height": "1.2",
+                  "width": "1.5"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-0.95",
+                  "y": "2.25",
+                  "z": "0.6"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "SimpleWhite"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "SimpleWhite"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "SimpleWhite"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "SimpleWhite"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "SimpleWhite"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "SimpleWhite"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "hexapod",
+              "body": [
+                {
+                  "selfCollide": "true",
+                  "ply": [
+                    {
+                      "filename": "ply/h4/h4head_reduced.ply",
+                      "name": "head",
+                      "pose": [
+                        {
+                          "gamma": "-180",
+                          "x": "0.0",
+                          "y": "1.311974",
+                          "z": "0.828109"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "97.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4main_reduced.ply",
+                      "name": "main",
+                      "pose": [
+                        {
+                          "gamma": "180",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "1.194516"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "73.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4tail_reduced.ply",
+                      "name": "tail",
+                      "pose": [
+                        {
+                          "gamma": "-180",
+                          "x": "0.0",
+                          "y": "-1.611996",
+                          "z": "0.729942"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "244.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg1_reduced.ply",
+                      "name": "left L1S1",
+                      "pose": [
+                        {
+                          "alpha": "-33.95327",
+                          "beta": "0",
+                          "gamma": "-45.703818",
+                          "x": "-0.369519",
+                          "y": "0.184943",
+                          "z": "0.777272"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "9.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg2_reduced.ply",
+                      "name": "left L1S2",
+                      "pose": [
+                        {
+                          "alpha": "-33.95327",
+                          "beta": "0.0",
+                          "gamma": "-151.601909",
+                          "x": "-0.707165",
+                          "y": "0.372142",
+                          "z": "0.828558"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "6.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg3_reduced.ply",
+                      "name": "left L1S3",
+                      "pose": [
+                        {
+                          "alpha": "-96.185224",
+                          "beta": "0.0",
+                          "gamma": "-151.601909",
+                          "x": "-1.079545",
+                          "y": "1.060895",
+                          "z": "0.870632"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg4.ply",
+                      "name": "left L1S4",
+                      "pose": [
+                        {
+                          "alpha": "54.424669",
+                          "beta": "-180",
+                          "gamma": "28.39813",
+                          "x": "-1.466908",
+                          "y": "1.777365",
+                          "z": "0.273804"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg1_reduced.ply",
+                      "name": "right L1S1",
+                      "pose": [
+                        {
+                          "alpha": "-39.064833",
+                          "beta": "0.0",
+                          "gamma": "30.623471",
+                          "x": "0.384198",
+                          "y": "0.118267",
+                          "z": "0.803203"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "9.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg2_reduced.ply",
+                      "name": "right L1S2",
+                      "pose": [
+                        {
+                          "alpha": "-39.064847",
+                          "beta": "0.0",
+                          "gamma": "156.274701",
+                          "x": "0.648176",
+                          "y": "0.246003",
+                          "z": "0.907809"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "6.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg3_reduced.ply",
+                      "name": "right L1S3",
+                      "pose": [
+                        {
+                          "alpha": "-106.373448",
+                          "beta": "0.0",
+                          "gamma": "156.274646",
+                          "x": "0.971616",
+                          "y": "0.981933",
+                          "z": "1.045528"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg4.ply",
+                      "name": "right L1S4",
+                      "pose": [
+                        {
+                          "alpha": "-106.373448",
+                          "beta": "0.0",
+                          "gamma": "156.27466",
+                          "x": "1.281028",
+                          "y": "1.685947",
+                          "z": "0.365667"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg1_reduced.ply",
+                      "name": "left L2S1",
+                      "pose": [
+                        {
+                          "alpha": "-113.937282",
+                          "beta": "0.0",
+                          "gamma": "135.823052",
+                          "x": "-0.2577",
+                          "y": "-0.115553",
+                          "z": "0.724711"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg2_reduced.ply",
+                      "name": "left L2S2",
+                      "pose": [
+                        {
+                          "alpha": "-31.877268",
+                          "beta": "0.0",
+                          "gamma": "135.823052",
+                          "x": "-0.54434",
+                          "y": "-0.410551",
+                          "z": "0.962445"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "6.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg3_reduced.ply",
+                      "name": "left L2S3",
+                      "pose": [
+                        {
+                          "alpha": "33.760754",
+                          "beta": "0.0",
+                          "gamma": "135.823052",
+                          "x": "-1.07631",
+                          "y": "-0.957955",
+                          "z": "1.211122"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg4.ply",
+                      "name": "left L2S4",
+                      "pose": [
+                        {
+                          "alpha": "34.475137",
+                          "beta": "0.0",
+                          "gamma": "135.823052",
+                          "x": "-1.63247",
+                          "y": "-1.530336",
+                          "z": "0.434763"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg1_reduced.ply",
+                      "name": "right L2S1",
+                      "pose": [
+                        {
+                          "alpha": "-113.937282",
+                          "beta": "0.0",
+                          "gamma": "-135.823052",
+                          "x": "0.2577",
+                          "y": "-0.115553",
+                          "z": "0.724711"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg2_reduced.ply",
+                      "name": "right L2S2",
+                      "pose": [
+                        {
+                          "alpha": "-31.877268",
+                          "beta": "0.0",
+                          "gamma": "-135.823052",
+                          "x": "0.54434",
+                          "y": "-0.410551",
+                          "z": "0.962445"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "6.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg3_reduced.ply",
+                      "name": "right L2S3",
+                      "pose": [
+                        {
+                          "alpha": "33.760754",
+                          "beta": "0.0",
+                          "gamma": "-135.823052",
+                          "x": "1.07631",
+                          "y": "-0.957955",
+                          "z": "1.211122"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg4.ply",
+                      "name": "right L2S4",
+                      "pose": [
+                        {
+                          "alpha": "34.475137",
+                          "beta": "0.0",
+                          "gamma": "-135.823052",
+                          "x": "1.63247",
+                          "y": "-1.530336",
+                          "z": "0.434763"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg1_reduced.ply",
+                      "name": "left L3S1",
+                      "pose": [
+                        {
+                          "alpha": "-74.274441",
+                          "beta": "0.0",
+                          "gamma": "146.885062",
+                          "x": "-0.2291",
+                          "y": "-0.630977",
+                          "z": "0.660947"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "5.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg2_reduced.ply",
+                      "name": "left L3S2",
+                      "pose": [
+                        {
+                          "alpha": "-35.061116",
+                          "beta": "0.0",
+                          "gamma": "146.885062",
+                          "x": "-0.52851",
+                          "y": "-1.090006",
+                          "z": "1.031232"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "9.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg3_reduced.ply",
+                      "name": "left L3S3",
+                      "pose": [
+                        {
+                          "alpha": "46.017221",
+                          "beta": "0.0",
+                          "gamma": "146.885062",
+                          "x": "-1.09468",
+                          "y": "-1.958001",
+                          "z": "1.332172"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "4.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg4.ply",
+                      "name": "left L3S4",
+                      "pose": [
+                        {
+                          "alpha": "46.017225",
+                          "beta": "0.0",
+                          "gamma": "146.885062",
+                          "x": "-1.76085",
+                          "y": "-2.979317",
+                          "z": "0.467886"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg1_reduced.ply",
+                      "name": "right L3S1",
+                      "pose": [
+                        {
+                          "alpha": "-74.274441",
+                          "beta": "0.0",
+                          "gamma": "-146.885062",
+                          "x": "0.2291",
+                          "y": "-0.630977",
+                          "z": "0.660947"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "5.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg2_reduced.ply",
+                      "name": "right L3S2",
+                      "pose": [
+                        {
+                          "alpha": "-35.061116",
+                          "beta": "0.0",
+                          "gamma": "-146.885062",
+                          "x": "0.52851",
+                          "y": "-1.090006",
+                          "z": "1.031232"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "9.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg3_reduced.ply",
+                      "name": "right L3S3",
+                      "pose": [
+                        {
+                          "alpha": "46.017221",
+                          "beta": "0.0",
+                          "gamma": "-146.885062",
+                          "x": "1.09468",
+                          "y": "-1.958001",
+                          "z": "1.332172"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "4.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg4.ply",
+                      "name": "right L3S4",
+                      "pose": [
+                        {
+                          "alpha": "46.017225",
+                          "beta": "0.0",
+                          "gamma": "-146.885062",
+                          "x": "1.76085",
+                          "y": "-2.979317",
+                          "z": "0.467886"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actuators": [
+                {
+                  "fixed": [
+                    {
+                      "name": "main head",
+                      "source": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "head"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "main tail",
+                      "source": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "tail"
+                        }
+                      ]
+                    }
+                  ],
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "right main - L1S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L1S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "0.108318",
+                          "z": "0.288676"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L1S1 - L1S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L1S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L1S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "0.46333",
+                          "z": "0.011461"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L1S2 - L1S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L1S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L1S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.348007",
+                          "z": "0.242132"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L1S3 - L1S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L1S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L1S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.481949",
+                          "z": "0.262414"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left main - L1S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L1S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "0.108318",
+                          "z": "0.288676"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L1S1 - L1S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L1S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L1S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "0.46333",
+                          "z": "0.011461"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L1S2 - L1S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L1S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L1S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.348007",
+                          "z": "0.242132"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L1S3 - L1S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L1S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L1S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.481949",
+                          "z": "0.262414"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right main - L2S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L2S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "-0.083263",
+                          "z": "-0.123404"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L2S1 - L2S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L2S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L2S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "-0.094742",
+                          "z": "-0.491264"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L2S2 - L2S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L2S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L2S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.165596",
+                          "z": "0.423891"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L2S3 - L2S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L2S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L2S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.052062",
+                          "z": "0.556805"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left main - L2S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L2S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "-0.083263",
+                          "z": "-0.123404"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L2S1 - L2S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L2S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L2S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "-0.094742",
+                          "z": "-0.491264"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L2S2 - L2S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L2S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L2S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.165596",
+                          "z": "0.423891"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L2S3 - L2S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L2S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L2S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.052062",
+                          "z": "0.556805"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right main - L3S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L3S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "-0.157125",
+                          "z": "-0.127871"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L3S1 - L3S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L3S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L3S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "-0.040014",
+                          "z": "-0.606707"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L3S2 - L3S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L3S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L3S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.156881",
+                          "z": "0.615627"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L3S3 - L3S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L3S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L3S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.066215",
+                          "z": "0.764271"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left main - L3S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L3S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "-0.157125",
+                          "z": "-0.127871"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L3S1 - L3S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L3S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L3S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "-0.040014",
+                          "z": "-0.606707"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L3S2 - L3S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L3S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L3S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.156881",
+                          "z": "0.615627"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L3S3 - L3S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L3S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L3S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.066215",
+                          "z": "0.764271"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "#children": [
+                    {
+                      "#tag": "deflection",
+                      "name": "right main - L1S1 sensor",
+                      "object": [
+                        {
+                          "name": "right main - L1S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L1S1 - L1S2 sensor",
+                      "object": [
+                        {
+                          "name": "right L1S1 - L1S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L1S2 - L1S3 sensor",
+                      "object": [
+                        {
+                          "name": "right L1S2 - L1S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L1S3 - L1S4 sensor",
+                      "object": [
+                        {
+                          "name": "right L1S3 - L1S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "right L1S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "right L1S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left main - L1S1 sensor",
+                      "object": [
+                        {
+                          "name": "left main - L1S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L1S1 - L1S2 sensor",
+                      "object": [
+                        {
+                          "name": "left L1S1 - L1S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L1S2 - L1S3 sensor",
+                      "object": [
+                        {
+                          "name": "left L1S2 - L1S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L1S3 - L1S4 sensor",
+                      "object": [
+                        {
+                          "name": "left L1S3 - L1S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "left L1S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "left L1S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right main - L2S1 sensor",
+                      "object": [
+                        {
+                          "name": "right main - L2S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L2S1 - L2S2 sensor",
+                      "object": [
+                        {
+                          "name": "right L2S1 - L2S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L2S2 - L2S3 sensor",
+                      "object": [
+                        {
+                          "name": "right L2S2 - L2S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L2S3 - L2S4 sensor",
+                      "object": [
+                        {
+                          "name": "right L2S3 - L2S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "right L2S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "right L2S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left main - L2S1 sensor",
+                      "object": [
+                        {
+                          "name": "left main - L2S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L2S1 - L2S2 sensor",
+                      "object": [
+                        {
+                          "name": "left L2S1 - L2S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L2S2 - L2S3 sensor",
+                      "object": [
+                        {
+                          "name": "left L2S2 - L2S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L2S3 - L2S4 sensor",
+                      "object": [
+                        {
+                          "name": "left L2S3 - L2S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "left L2S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "left L2S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right main - L3S1 sensor",
+                      "object": [
+                        {
+                          "name": "right main - L3S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L3S1 - L3S2 sensor",
+                      "object": [
+                        {
+                          "name": "right L3S1 - L3S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L3S2 - L3S3 sensor",
+                      "object": [
+                        {
+                          "name": "right L3S2 - L3S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L3S3 - L3S4 sensor",
+                      "object": [
+                        {
+                          "name": "right L3S3 - L3S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "right L3S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "right L3S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left main - L3S1 sensor",
+                      "object": [
+                        {
+                          "name": "left main - L3S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L3S1 - L3S2 sensor",
+                      "object": [
+                        {
+                          "name": "left L3S1 - L3S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L3S2 - L3S3 sensor",
+                      "object": [
+                        {
+                          "name": "left L3S2 - L3S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L3S3 - L3S4 sensor",
+                      "object": [
+                        {
+                          "name": "left L3S3 - L3S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "left L3S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "left L3S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "position",
+                      "name": "main body position",
+                      "object": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "logging": [
+        {
+          "object": [
+            {
+              "precision": "3",
+              "target": "main",
+              "use": [
+                {
+                  "value": "x"
+                },
+                {
+                  "value": "y"
+                },
+                {
+                  "value": "z"
+                }
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "head",
+              "use": [
+                {
+                  "value": "x"
+                },
+                {
+                  "value": "y"
+                },
+                {
+                  "value": "z"
+                }
+              ]
+            },
+            {
+              "precision": "3",
+              "target": "tail",
+              "use": [
+                {
+                  "value": "x"
+                },
+                {
+                  "value": "y"
+                },
+                {
+                  "value": "z"
+                }
+              ]
+            }
+          ],
+          "csv": [
+            {
+              "name": "hexapod",
+              "target": [
+                {
+                  "name": "main"
+                },
+                {
+                  "name": "head"
+                },
+                {
+                  "name": "tail"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/hexapod_low.json
+++ b/xml/hexapod_low.json
@@ -1,0 +1,2369 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "capture": "false",
+              "follow": "true",
+              "name": "main",
+              "show": "true",
+              "resolution": [
+                {
+                  "name": "720p"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "7.00",
+                      "y": "0.00",
+                      "z": "2.0"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.0",
+                      "z": "1.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "800040",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "-0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.25"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.25"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.000",
+                      "i": "0.0000",
+                      "p": "0.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.50"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.50"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.00"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "name": "env",
+          "ground": [
+            {
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGround"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "hexapod",
+              "body": [
+                {
+                  "selfCollide": "true",
+                  "ply": [
+                    {
+                      "convex": "false",
+                      "filename": "ply/main_body.ply",
+                      "name": "main body",
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.449429"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "MainBodyMesh.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "50"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_right.ply",
+                      "name": "rear right femur",
+                      "pose": [
+                        {
+                          "x": "0.700179",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearFemurMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_right.ply",
+                      "name": "rear right tibia",
+                      "pose": [
+                        {
+                          "x": "1.080657",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTibiaMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_right.ply",
+                      "name": "rear right tarsus",
+                      "pose": [
+                        {
+                          "x": "1.613118",
+                          "y": "-2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTarsusMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_right.ply",
+                      "name": "centre right femur",
+                      "pose": [
+                        {
+                          "x": "0.700179",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreFemurMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_right.ply",
+                      "name": "centre right tibia",
+                      "pose": [
+                        {
+                          "x": "1.080657",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTibiaMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_right.ply",
+                      "name": "centre right tarsus",
+                      "pose": [
+                        {
+                          "x": "1.613118",
+                          "y": "0.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTarsusMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_right.ply",
+                      "name": "front right femur",
+                      "pose": [
+                        {
+                          "x": "0.700179",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontFemurMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_right.ply",
+                      "name": "front right tibia",
+                      "pose": [
+                        {
+                          "x": "1.080657",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTibiaMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_right.ply",
+                      "name": "front right tarsus",
+                      "pose": [
+                        {
+                          "x": "1.613118",
+                          "y": "2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTarsusMesh_R.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_left.ply",
+                      "name": "rear left femur",
+                      "pose": [
+                        {
+                          "x": "-0.700179",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearFemurMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_left.ply",
+                      "name": "rear left tibia",
+                      "pose": [
+                        {
+                          "x": "-1.080657",
+                          "y": "-2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTibiaMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_left.ply",
+                      "name": "rear left tarsus",
+                      "pose": [
+                        {
+                          "x": "-1.613118",
+                          "y": "-2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "RearTarsusMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_left.ply",
+                      "name": "centre left femur",
+                      "pose": [
+                        {
+                          "x": "-0.700179",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreFemurMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_left.ply",
+                      "name": "centre left tibia",
+                      "pose": [
+                        {
+                          "x": "-1.080657",
+                          "y": "0.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTibiaMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_left.ply",
+                      "name": "centre left tarsus",
+                      "pose": [
+                        {
+                          "x": "-1.613118",
+                          "y": "0.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "CentreTarsusMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/femur_left.ply",
+                      "name": "front left femur",
+                      "pose": [
+                        {
+                          "x": "-0.700179",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontFemurMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".2"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tibia_left.ply",
+                      "name": "front left tibia",
+                      "pose": [
+                        {
+                          "x": "-1.080657",
+                          "y": "2.0",
+                          "z": "0.851405"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTibiaMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".15"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/tarsus_left.ply",
+                      "name": "front left tarsus",
+                      "pose": [
+                        {
+                          "x": "-1.613118",
+                          "y": "2.0",
+                          "z": "0.208994"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "mesh": [
+                            {
+                              "name": "FrontTarsusMesh_L.mesh",
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.0"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": ".1"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actuators": [
+                {
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "front right z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90",
+                          "x": "-0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "front right y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front right tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "front left z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "-90",
+                          "x": "0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "front left y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "front left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front left tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-90",
+                          "x": "-0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre right z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90",
+                          "x": "-0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre right y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre right tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre left z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "-90",
+                          "x": "0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "centre left y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "centre left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre left tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-90",
+                          "x": "-0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear right z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90",
+                          "x": "-0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear right y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear right femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear right tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear left z-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "-90",
+                          "x": "0.275206",
+                          "y": "0.0",
+                          "z": "-0.398469"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "rear left y-axis",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "rear left femur"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear left tibia"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "20.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.75"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-90",
+                          "x": "-0.353679",
+                          "y": "0.0",
+                          "z": "0.464797"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "1"
+                        }
+                      ]
+                    }
+                  ],
+                  "fixed": [
+                    {
+                      "name": "front left ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "front left tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front left tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre left ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "centre left tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre left tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear left ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "rear left tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear left tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "front right ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "front right tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "front right tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre right ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "centre right tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "centre right tarsus"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear right ti-ta fixed",
+                      "source": [
+                        {
+                          "name": "rear right tibia"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear right tarsus"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "deflection": [
+                    {
+                      "name": "front right z-axis sensor",
+                      "object": [
+                        {
+                          "name": "front right z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "front right y-axis sensor",
+                      "object": [
+                        {
+                          "name": "front right y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "front left z-axis sensor",
+                      "object": [
+                        {
+                          "name": "front left z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "front left y-axis sensor",
+                      "object": [
+                        {
+                          "name": "front left y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre right z-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre right z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre right y-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre right y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre left z-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre left z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "centre left y-axis sensor",
+                      "object": [
+                        {
+                          "name": "centre left y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear right z-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear right z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear right y-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear right y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear left z-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear left z-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "35",
+                          "min": "-35"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "rear left y-axis sensor",
+                      "object": [
+                        {
+                          "name": "rear left y-axis"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25",
+                          "min": "-15"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    }
+                  ],
+                  "position": [
+                    {
+                      "name": "main body position",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "ov": [
+                    {
+                      "name": "main body velocity",
+                      "object": [
+                        {
+                          "name": "main body"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Python",
+                  "parameter": [
+                    {
+                      "name": "module",
+                      "value": "hexapod"
+                    },
+                    {
+                      "name": "working directory",
+                      "value": "/Users/zahedi/projects/yars/contrib/controller"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "project": "xy",
+              "target": "main body",
+              "time": "20",
+              "init": [
+                {
+                  "colour": "009cff",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "009cff00",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.05"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front left femur",
+              "time": "20",
+              "init": [
+                {
+                  "colour": "95aeca",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "95aeca00",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front left tarsus",
+              "time": "20",
+              "init": [
+                {
+                  "colour": "668092",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "66809200",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front right femur",
+              "time": "20",
+              "init": [
+                {
+                  "colour": "95aeca",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "95aeca00",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            },
+            {
+              "length": "15",
+              "max": "1000",
+              "particles": "false",
+              "target": "front right tarsus",
+              "time": "20",
+              "init": [
+                {
+                  "colour": "668092",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "66809200",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "true",
+                  "z": "0.0"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/hexapod_mpi.json
+++ b/xml/hexapod_mpi.json
@@ -1,0 +1,3162 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "200"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "capture": "false",
+              "follow": "true",
+              "name": "main",
+              "show": "true",
+              "resolution": [
+                {
+                  "name": "720p"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "7.00",
+                      "y": "0.00",
+                      "z": "3.5"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.0",
+                      "z": "1.5"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "800000",
+                      "font": "Time",
+                      "size": "24"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "800000",
+                      "font": "Robot",
+                      "size": "24"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.0"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "name": "env",
+          "ground": [
+            {
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGround"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "hexapod",
+              "body": [
+                {
+                  "selfCollide": "true",
+                  "ply": [
+                    {
+                      "filename": "ply/h4/h4head_reduced.ply",
+                      "name": "head",
+                      "pose": [
+                        {
+                          "gamma": "-180",
+                          "x": "0.0",
+                          "y": "1.311974",
+                          "z": "0.828109"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "97.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4main_reduced.ply",
+                      "name": "main",
+                      "pose": [
+                        {
+                          "gamma": "180",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "1.194516"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "73.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4tail_reduced.ply",
+                      "name": "tail",
+                      "pose": [
+                        {
+                          "gamma": "-180",
+                          "x": "0.0",
+                          "y": "-1.611996",
+                          "z": "0.729942"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "244.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg1_reduced.ply",
+                      "name": "left L1S1",
+                      "pose": [
+                        {
+                          "alpha": "-33.95327",
+                          "beta": "0",
+                          "gamma": "-45.703818",
+                          "x": "-0.369519",
+                          "y": "0.184943",
+                          "z": "0.777272"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "9.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg2_reduced.ply",
+                      "name": "left L1S2",
+                      "pose": [
+                        {
+                          "alpha": "-33.95327",
+                          "beta": "0.0",
+                          "gamma": "-151.601909",
+                          "x": "-0.707165",
+                          "y": "0.372142",
+                          "z": "0.828558"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "6.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg3_reduced.ply",
+                      "name": "left L1S3",
+                      "pose": [
+                        {
+                          "alpha": "-96.185224",
+                          "beta": "0.0",
+                          "gamma": "-151.601909",
+                          "x": "-1.079545",
+                          "y": "1.060895",
+                          "z": "0.870632"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg4.ply",
+                      "name": "left L1S4",
+                      "pose": [
+                        {
+                          "alpha": "54.424669",
+                          "beta": "-180",
+                          "gamma": "28.39813",
+                          "x": "-1.466908",
+                          "y": "1.777365",
+                          "z": "0.273804"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg1_reduced.ply",
+                      "name": "right L1S1",
+                      "pose": [
+                        {
+                          "alpha": "-39.064833",
+                          "beta": "0.0",
+                          "gamma": "30.623471",
+                          "x": "0.384198",
+                          "y": "0.118267",
+                          "z": "0.803203"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "9.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg2_reduced.ply",
+                      "name": "right L1S2",
+                      "pose": [
+                        {
+                          "alpha": "-39.064847",
+                          "beta": "0.0",
+                          "gamma": "156.274701",
+                          "x": "0.648176",
+                          "y": "0.246003",
+                          "z": "0.907809"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "6.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg3_reduced.ply",
+                      "name": "right L1S3",
+                      "pose": [
+                        {
+                          "alpha": "-106.373448",
+                          "beta": "0.0",
+                          "gamma": "156.274646",
+                          "x": "0.971616",
+                          "y": "0.981933",
+                          "z": "1.045528"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg4.ply",
+                      "name": "right L1S4",
+                      "pose": [
+                        {
+                          "alpha": "-106.373448",
+                          "beta": "0.0",
+                          "gamma": "156.27466",
+                          "x": "1.281028",
+                          "y": "1.685947",
+                          "z": "0.365667"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg1_reduced.ply",
+                      "name": "left L2S1",
+                      "pose": [
+                        {
+                          "alpha": "-113.937282",
+                          "beta": "0.0",
+                          "gamma": "135.823052",
+                          "x": "-0.2577",
+                          "y": "-0.115553",
+                          "z": "0.724711"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg2_reduced.ply",
+                      "name": "left L2S2",
+                      "pose": [
+                        {
+                          "alpha": "-31.877268",
+                          "beta": "0.0",
+                          "gamma": "135.823052",
+                          "x": "-0.54434",
+                          "y": "-0.410551",
+                          "z": "0.962445"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "6.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg3_reduced.ply",
+                      "name": "left L2S3",
+                      "pose": [
+                        {
+                          "alpha": "33.760754",
+                          "beta": "0.0",
+                          "gamma": "135.823052",
+                          "x": "-1.07631",
+                          "y": "-0.957955",
+                          "z": "1.211122"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg4.ply",
+                      "name": "left L2S4",
+                      "pose": [
+                        {
+                          "alpha": "34.475137",
+                          "beta": "0.0",
+                          "gamma": "135.823052",
+                          "x": "-1.63247",
+                          "y": "-1.530336",
+                          "z": "0.434763"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg1_reduced.ply",
+                      "name": "right L2S1",
+                      "pose": [
+                        {
+                          "alpha": "-113.937282",
+                          "beta": "0.0",
+                          "gamma": "-135.823052",
+                          "x": "0.2577",
+                          "y": "-0.115553",
+                          "z": "0.724711"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg2_reduced.ply",
+                      "name": "right L2S2",
+                      "pose": [
+                        {
+                          "alpha": "-31.877268",
+                          "beta": "0.0",
+                          "gamma": "-135.823052",
+                          "x": "0.54434",
+                          "y": "-0.410551",
+                          "z": "0.962445"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "6.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg3_reduced.ply",
+                      "name": "right L2S3",
+                      "pose": [
+                        {
+                          "alpha": "33.760754",
+                          "beta": "0.0",
+                          "gamma": "-135.823052",
+                          "x": "1.07631",
+                          "y": "-0.957955",
+                          "z": "1.211122"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg4.ply",
+                      "name": "right L2S4",
+                      "pose": [
+                        {
+                          "alpha": "34.475137",
+                          "beta": "0.0",
+                          "gamma": "-135.823052",
+                          "x": "1.63247",
+                          "y": "-1.530336",
+                          "z": "0.434763"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg1_reduced.ply",
+                      "name": "left L3S1",
+                      "pose": [
+                        {
+                          "alpha": "-74.274441",
+                          "beta": "0.0",
+                          "gamma": "146.885062",
+                          "x": "-0.2291",
+                          "y": "-0.630977",
+                          "z": "0.660947"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "5.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg2_reduced.ply",
+                      "name": "left L3S2",
+                      "pose": [
+                        {
+                          "alpha": "-35.061116",
+                          "beta": "0.0",
+                          "gamma": "146.885062",
+                          "x": "-0.52851",
+                          "y": "-1.090006",
+                          "z": "1.031232"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "9.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg3_reduced.ply",
+                      "name": "left L3S3",
+                      "pose": [
+                        {
+                          "alpha": "46.017221",
+                          "beta": "0.0",
+                          "gamma": "146.885062",
+                          "x": "-1.09468",
+                          "y": "-1.958001",
+                          "z": "1.332172"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "4.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg4.ply",
+                      "name": "left L3S4",
+                      "pose": [
+                        {
+                          "alpha": "46.017225",
+                          "beta": "0.0",
+                          "gamma": "146.885062",
+                          "x": "-1.76085",
+                          "y": "-2.979317",
+                          "z": "0.467886"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg1_reduced.ply",
+                      "name": "right L3S1",
+                      "pose": [
+                        {
+                          "alpha": "-74.274441",
+                          "beta": "0.0",
+                          "gamma": "-146.885062",
+                          "x": "0.2291",
+                          "y": "-0.630977",
+                          "z": "0.660947"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "5.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg2_reduced.ply",
+                      "name": "right L3S2",
+                      "pose": [
+                        {
+                          "alpha": "-35.061116",
+                          "beta": "0.0",
+                          "gamma": "-146.885062",
+                          "x": "0.52851",
+                          "y": "-1.090006",
+                          "z": "1.031232"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "9.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg3_reduced.ply",
+                      "name": "right L3S3",
+                      "pose": [
+                        {
+                          "alpha": "46.017221",
+                          "beta": "0.0",
+                          "gamma": "-146.885062",
+                          "x": "1.09468",
+                          "y": "-1.958001",
+                          "z": "1.332172"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "4.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg4.ply",
+                      "name": "right L3S4",
+                      "pose": [
+                        {
+                          "alpha": "46.017225",
+                          "beta": "0.0",
+                          "gamma": "-146.885062",
+                          "x": "1.76085",
+                          "y": "-2.979317",
+                          "z": "0.467886"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actuators": [
+                {
+                  "fixed": [
+                    {
+                      "name": "main head",
+                      "source": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "head"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "main tail",
+                      "source": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "tail"
+                        }
+                      ]
+                    }
+                  ],
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "right main - L1S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L1S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "0.108318",
+                          "z": "0.288676"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L1S1 - L1S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L1S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L1S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "0.46333",
+                          "z": "0.011461"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L1S2 - L1S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L1S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L1S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.348007",
+                          "z": "0.242132"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L1S3 - L1S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L1S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L1S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.481949",
+                          "z": "0.262414"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left main - L1S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L1S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "0.108318",
+                          "z": "0.288676"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L1S1 - L1S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L1S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L1S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "0.46333",
+                          "z": "0.011461"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L1S2 - L1S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L1S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L1S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.348007",
+                          "z": "0.242132"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L1S3 - L1S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L1S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L1S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.481949",
+                          "z": "0.262414"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right main - L2S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L2S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "-0.083263",
+                          "z": "-0.123404"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L2S1 - L2S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L2S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L2S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "-0.094742",
+                          "z": "-0.491264"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L2S2 - L2S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L2S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L2S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.165596",
+                          "z": "0.423891"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L2S3 - L2S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L2S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L2S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.052062",
+                          "z": "0.556805"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left main - L2S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L2S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "-0.083263",
+                          "z": "-0.123404"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L2S1 - L2S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L2S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L2S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "-0.094742",
+                          "z": "-0.491264"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L2S2 - L2S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L2S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L2S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.165596",
+                          "z": "0.423891"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L2S3 - L2S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L2S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L2S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.052062",
+                          "z": "0.556805"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right main - L3S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L3S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "-0.157125",
+                          "z": "-0.127871"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L3S1 - L3S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L3S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L3S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "-0.040014",
+                          "z": "-0.606707"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L3S2 - L3S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L3S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L3S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.156881",
+                          "z": "0.615627"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L3S3 - L3S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L3S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L3S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.066215",
+                          "z": "0.764271"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left main - L3S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L3S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "-0.157125",
+                          "z": "-0.127871"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L3S1 - L3S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L3S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L3S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "-0.040014",
+                          "z": "-0.606707"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L3S2 - L3S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L3S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L3S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.156881",
+                          "z": "0.615627"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L3S3 - L3S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L3S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L3S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.066215",
+                          "z": "0.764271"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "#children": [
+                    {
+                      "#tag": "deflection",
+                      "name": "right main - L1S1 sensor",
+                      "object": [
+                        {
+                          "name": "right main - L1S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L1S1 - L1S2 sensor",
+                      "object": [
+                        {
+                          "name": "right L1S1 - L1S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L1S2 - L1S3 sensor",
+                      "object": [
+                        {
+                          "name": "right L1S2 - L1S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L1S3 - L1S4 sensor",
+                      "object": [
+                        {
+                          "name": "right L1S3 - L1S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "right L1S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "right L1S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left main - L1S1 sensor",
+                      "object": [
+                        {
+                          "name": "left main - L1S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L1S1 - L1S2 sensor",
+                      "object": [
+                        {
+                          "name": "left L1S1 - L1S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L1S2 - L1S3 sensor",
+                      "object": [
+                        {
+                          "name": "left L1S2 - L1S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L1S3 - L1S4 sensor",
+                      "object": [
+                        {
+                          "name": "left L1S3 - L1S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "left L1S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "left L1S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right main - L2S1 sensor",
+                      "object": [
+                        {
+                          "name": "right main - L2S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L2S1 - L2S2 sensor",
+                      "object": [
+                        {
+                          "name": "right L2S1 - L2S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L2S2 - L2S3 sensor",
+                      "object": [
+                        {
+                          "name": "right L2S2 - L2S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L2S3 - L2S4 sensor",
+                      "object": [
+                        {
+                          "name": "right L2S3 - L2S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "right L2S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "right L2S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left main - L2S1 sensor",
+                      "object": [
+                        {
+                          "name": "left main - L2S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L2S1 - L2S2 sensor",
+                      "object": [
+                        {
+                          "name": "left L2S1 - L2S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L2S2 - L2S3 sensor",
+                      "object": [
+                        {
+                          "name": "left L2S2 - L2S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L2S3 - L2S4 sensor",
+                      "object": [
+                        {
+                          "name": "left L2S3 - L2S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "left L2S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "left L2S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right main - L3S1 sensor",
+                      "object": [
+                        {
+                          "name": "right main - L3S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L3S1 - L3S2 sensor",
+                      "object": [
+                        {
+                          "name": "right L3S1 - L3S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L3S2 - L3S3 sensor",
+                      "object": [
+                        {
+                          "name": "right L3S2 - L3S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L3S3 - L3S4 sensor",
+                      "object": [
+                        {
+                          "name": "right L3S3 - L3S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "right L3S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "right L3S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left main - L3S1 sensor",
+                      "object": [
+                        {
+                          "name": "left main - L3S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L3S1 - L3S2 sensor",
+                      "object": [
+                        {
+                          "name": "left L3S1 - L3S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L3S2 - L3S3 sensor",
+                      "object": [
+                        {
+                          "name": "left L3S2 - L3S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L3S3 - L3S4 sensor",
+                      "object": [
+                        {
+                          "name": "left L3S3 - L3S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "left L3S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "left L3S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "position",
+                      "name": "main body position",
+                      "object": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/hexapod_ralf.json
+++ b/xml/hexapod_ralf.json
@@ -1,0 +1,3457 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "200"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "capture": "false",
+              "follow": "true",
+              "name": "main",
+              "show": "true",
+              "resolution": [
+                {
+                  "name": "720p"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "5.0",
+                      "y": "5.0",
+                      "z": "5.5"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.0",
+                      "z": "2.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "800040",
+                      "font": "Time",
+                      "size": "24"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "800040",
+                      "font": "Robot",
+                      "size": "24"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.0",
+                  "fromX": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.7"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.7"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "name": "env",
+          "ground": [
+            {
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGround"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "hexapod",
+              "body": [
+                {
+                  "selfCollide": "false",
+                  "ply": [
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Main_reduced.ply",
+                      "name": "main",
+                      "pose": [
+                        {
+                          "z": "0.5"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "20.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Head_reduced.ply",
+                      "name": "head",
+                      "pose": [
+                        {
+                          "y": "0.825276",
+                          "z": "0.553054"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "10.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Rear_reduced.ply",
+                      "name": "rear",
+                      "pose": [
+                        {
+                          "y": "-1.389205",
+                          "z": "0.618514"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "6.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Femur_F_R_reduced.ply",
+                      "name": "femur front right",
+                      "pose": [
+                        {
+                          "x": "0.583046",
+                          "y": "0.767045",
+                          "z": "0.847976"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "2.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Tibia_F_R_reduced.ply",
+                      "name": "tibia front right",
+                      "pose": [
+                        {
+                          "x": "0.917606",
+                          "y": "1.346437",
+                          "z": "0.913042"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.5"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Tarsus_F_R_reduced.ply",
+                      "name": "tarsus front right",
+                      "pose": [
+                        {
+                          "x": "1.30757",
+                          "y": "2.021959",
+                          "z": "0.254967"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "3.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Femur_F_L_reduced.ply",
+                      "name": "femur front left",
+                      "pose": [
+                        {
+                          "x": "-0.583046",
+                          "y": "0.767045",
+                          "z": "0.847976"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "2.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Tibia_F_L_reduced.ply",
+                      "name": "tibia front left",
+                      "pose": [
+                        {
+                          "x": "-0.917606",
+                          "y": "1.346437",
+                          "z": "0.913042"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.5"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "3.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Tarsus_F_L_reduced.ply",
+                      "name": "tarsus front left",
+                      "pose": [
+                        {
+                          "x": "-1.30757",
+                          "y": "2.021959",
+                          "z": "0.254967"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "3.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Femur_C_R_reduced.ply",
+                      "name": "femur centre right",
+                      "pose": [
+                        {
+                          "x": "0.700179",
+                          "y": "0.0",
+                          "z": "0.859246"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "2.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Tibia_C_R_reduced.ply",
+                      "name": "tibia centre right",
+                      "pose": [
+                        {
+                          "x": "1.080656",
+                          "y": "0.0",
+                          "z": "0.903537"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.5"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "3.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Tarsus_C_R_reduced.ply",
+                      "name": "tarsus centre right",
+                      "pose": [
+                        {
+                          "x": "1.613117",
+                          "y": "0.0",
+                          "z": "0.261126"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "3.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Femur_C_L_reduced.ply",
+                      "name": "femur centre left",
+                      "pose": [
+                        {
+                          "x": "-0.700179",
+                          "y": "0.0",
+                          "z": "0.859246"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "2.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Tibia_C_L_reduced.ply",
+                      "name": "tibia centre left",
+                      "pose": [
+                        {
+                          "x": "-1.080656",
+                          "y": "0.0",
+                          "z": "0.903537"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.5"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "3.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Tarsus_C_L_reduced.ply",
+                      "name": "tarsus centre left",
+                      "pose": [
+                        {
+                          "x": "-1.613117",
+                          "y": "0.0",
+                          "z": "0.261126"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "3.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Femur_R_R_reduced.ply",
+                      "name": "femur rear right",
+                      "pose": [
+                        {
+                          "x": "0.690446",
+                          "y": "-0.953069",
+                          "z": "0.892816"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "4.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Tibia_R_R_reduced.ply",
+                      "name": "tibia rear right",
+                      "pose": [
+                        {
+                          "x": "1.129061",
+                          "y": "-1.712857",
+                          "z": "0.911182"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "3.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Tarsus_R_R_reduced.ply",
+                      "name": "tarsus rear right",
+                      "pose": [
+                        {
+                          "x": "1.645274",
+                          "y": "-2.606881",
+                          "z": "0.250164"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "2.4"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "3.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Femur_R_L_reduced.ply",
+                      "name": "femur rear left",
+                      "pose": [
+                        {
+                          "x": "-0.690446",
+                          "y": "-0.953069",
+                          "z": "0.892816"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "4.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "1.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Tibia_R_L_reduced.ply",
+                      "name": "tibia rear left",
+                      "pose": [
+                        {
+                          "x": "-1.129061",
+                          "y": "-1.712857",
+                          "z": "0.911182"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "3.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "convex": "false",
+                      "filename": "ply/ralf/Tarsus_R_L_reduced.ply",
+                      "name": "tarsus rear left",
+                      "pose": [
+                        {
+                          "x": "-1.645274",
+                          "y": "-2.606881",
+                          "z": "0.250164"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "2.4"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "3.0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "pose": [
+                {
+                  "z": "2.0"
+                }
+              ],
+              "actuators": [
+                {
+                  "#children": [
+                    {
+                      "#tag": "generic",
+                      "name": "front left Fe-Ma",
+                      "spring": "false",
+                      "source": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "femur front left"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "30",
+                          "x": "-0.345967",
+                          "y": "0.356388",
+                          "z": "-0.094383"
+                        }
+                      ],
+                      "rotational": [
+                        {
+                          "x": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "100.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "20.0",
+                                  "min": "-5.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ],
+                          "z": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "100.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "35",
+                                  "min": "-45"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "generic",
+                      "name": "front right Fe-Ma",
+                      "spring": "false",
+                      "source": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "femur front right"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-30",
+                          "x": "0.345967",
+                          "y": "0.356388",
+                          "z": "-0.094383"
+                        }
+                      ],
+                      "rotational": [
+                        {
+                          "x": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "100.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "20.0",
+                                  "min": "-5.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ],
+                          "z": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "100.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "45",
+                                  "min": "-35"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "-1",
+                                  "min": "1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "generic",
+                      "name": "centre left Fe-Ma",
+                      "source": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "femur centre left"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "-0.373759",
+                          "y": "0.0",
+                          "z": "-0.15891"
+                        }
+                      ],
+                      "rotational": [
+                        {
+                          "y": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "100.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "45.0",
+                                  "min": "-0.5"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ],
+                          "z": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "100.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "45",
+                                  "min": "-45"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "generic",
+                      "name": "centre right Fe-Ma",
+                      "source": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "femur centre right"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.373759",
+                          "y": "0.0",
+                          "z": "-0.15891"
+                        }
+                      ],
+                      "rotational": [
+                        {
+                          "y": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "100.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "0.5",
+                                  "min": "-45.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "-1",
+                                  "min": "1"
+                                }
+                              ]
+                            }
+                          ],
+                          "z": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "100.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "45",
+                                  "min": "-45"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "-1",
+                                  "min": "1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "generic",
+                      "name": "rear left Fe-Ma",
+                      "source": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "femur rear left"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-120",
+                          "x": "-0.350748",
+                          "y": "-0.364688",
+                          "z": "-0.163432"
+                        }
+                      ],
+                      "rotational": [
+                        {
+                          "y": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "200.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "5.0",
+                                  "min": "-20.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "-1",
+                                  "min": "1"
+                                }
+                              ]
+                            }
+                          ],
+                          "z": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "200.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "30",
+                                  "min": "-20"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "generic",
+                      "name": "rear right Fe-Ma",
+                      "source": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "femur rear right"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "120",
+                          "x": "0.350748",
+                          "y": "-0.364688",
+                          "z": "-0.163432"
+                        }
+                      ],
+                      "rotational": [
+                        {
+                          "y": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "200.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "20.0",
+                                  "min": "-5.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ],
+                          "z": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "200.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "20",
+                                  "min": "-30"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "-1",
+                                  "min": "1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "hinge",
+                      "mode": "active",
+                      "name": "front left Fe-Ti",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "femur front left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "tibia front left"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "200.0",
+                          "scaling": "5.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "4.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "30",
+                          "x": "-0.285346",
+                          "y": "0.494232",
+                          "z": "0.468772"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "10.0",
+                          "min": "-15.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "hinge",
+                      "mode": "active",
+                      "name": "front right Fe-Ti",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "femur front right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "tibia front right"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "200.0",
+                          "scaling": "5.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "4.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-30",
+                          "x": "0.285346",
+                          "y": "0.494232",
+                          "z": "0.468772"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "10.0",
+                          "min": "-15.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "hinge",
+                      "mode": "active",
+                      "name": "centre left Fe-Ti",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "femur centre left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "tibia centre left"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "100.0",
+                          "scaling": "5.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "4.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "-0.385284",
+                          "y": "0.0",
+                          "z": "0.464624"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-2.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "hinge",
+                      "mode": "active",
+                      "name": "centre right Fe-Ti",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "femur centre right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "tibia centre right"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "100.0",
+                          "scaling": "5.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "4.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-90",
+                          "x": "0.385284",
+                          "y": "0.0",
+                          "z": "0.464624"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-2.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "hinge",
+                      "mode": "active",
+                      "name": "rear left Fe-Ti",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "femur rear left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "tibia rear left"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "400.0",
+                          "scaling": "5.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "4.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-30",
+                          "x": "-0.354114",
+                          "y": "-0.613342",
+                          "z": "0.42241"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "27.5",
+                          "min": "-5.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "hinge",
+                      "mode": "active",
+                      "name": "rear right Fe-Ti",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "femur rear right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "tibia rear right"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "400.0",
+                          "scaling": "5.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "4.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "30",
+                          "x": "0.354114",
+                          "y": "-0.613342",
+                          "z": "0.42241"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "27.5",
+                          "min": "-5.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "hinge",
+                      "mode": "active",
+                      "name": "front left Ti-Ta",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "tibia front left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "tarsus front left"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "200.0",
+                          "scaling": "5.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "4.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "30",
+                          "x": "-0.069505",
+                          "y": "0.120302",
+                          "z": "-0.476651"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "5.0",
+                          "min": "-30.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "hinge",
+                      "mode": "active",
+                      "name": "front right Ti-Ta",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "tibia front right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "tarsus front right"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "200.0",
+                          "scaling": "5.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "4.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-30",
+                          "x": "0.069505",
+                          "y": "0.120302",
+                          "z": "-0.476651"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "5.0",
+                          "min": "-30.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "hinge",
+                      "mode": "active",
+                      "name": "centre left Ti-Ta",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "tibia centre left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "tarsus centre left"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "150.0",
+                          "scaling": "5.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "4.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "-0.008504",
+                          "y": "0.0",
+                          "z": "-0.471905"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "5.0",
+                          "min": "-30.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "hinge",
+                      "mode": "active",
+                      "name": "centre right Ti-Ta",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "tibia centre right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "tarsus centre right"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "150.0",
+                          "scaling": "5.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "4.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.008504",
+                          "y": "0.0",
+                          "z": "-0.471905"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "30.0",
+                          "min": "-5.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "hinge",
+                      "mode": "active",
+                      "name": "rear left Ti-Ta",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "tibia rear left"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "tarsus rear left"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "250.0",
+                          "scaling": "5.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "4.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "-30",
+                          "x": "-0.10703",
+                          "y": "-0.185465",
+                          "z": "-0.465533"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "20.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "hinge",
+                      "mode": "active",
+                      "name": "rear right Ti-Ta",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "tibia rear right"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "tarsus rear right"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "250.0",
+                          "scaling": "5.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "4.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "30",
+                          "x": "0.10703",
+                          "y": "-0.185465",
+                          "z": "-0.465533"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "20.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "generic",
+                      "name": "main - rear",
+                      "spring": "false",
+                      "source": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "rear"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.5",
+                          "z": "0.0"
+                        }
+                      ],
+                      "rotational": [
+                        {
+                          "x": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "1.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "6.0",
+                                  "min": "-5.5"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ],
+                          "z": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "1.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "6.0",
+                                  "min": "-6.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "generic",
+                      "name": "main - head",
+                      "spring": "false",
+                      "source": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "head"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "0.5",
+                          "z": "0.0"
+                        }
+                      ],
+                      "rotational": [
+                        {
+                          "x": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "1.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "6.0",
+                                  "min": "-5.5"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ],
+                          "z": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "1.0",
+                                  "scaling": "5.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "4.0"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "6.0",
+                                  "min": "-6.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "#children": [
+                    {
+                      "#tag": "generic",
+                      "name": "sensor front left Fe-Ma",
+                      "object": [
+                        {
+                          "name": "front left Fe-Ma"
+                        }
+                      ],
+                      "x": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "20.0",
+                                  "min": "-5.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "z": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "35",
+                                  "min": "-45"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "generic",
+                      "name": "sensor front right Fe-Ma",
+                      "object": [
+                        {
+                          "name": "front right Fe-Ma"
+                        }
+                      ],
+                      "x": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "20.0",
+                                  "min": "-5.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "z": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "45",
+                                  "min": "-35"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "-1",
+                                  "min": "1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "generic",
+                      "name": "sensor centre left Fe-Ma",
+                      "object": [
+                        {
+                          "name": "centre left Fe-Ma"
+                        }
+                      ],
+                      "y": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "45.0",
+                                  "min": "-0.5"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "z": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "45",
+                                  "min": "-45"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "generic",
+                      "name": "sensor centre right Fe-Ma",
+                      "object": [
+                        {
+                          "name": "centre right Fe-Ma"
+                        }
+                      ],
+                      "y": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "0.5",
+                                  "min": "-45.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "-1",
+                                  "min": "1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "z": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "45",
+                                  "min": "-45"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "-1",
+                                  "min": "1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "generic",
+                      "name": "sensor rear left Fe-Ma",
+                      "object": [
+                        {
+                          "name": "rear left Fe-Ma"
+                        }
+                      ],
+                      "y": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "5.0",
+                                  "min": "-20.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "-1",
+                                  "min": "1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "z": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "30",
+                                  "min": "-20"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "generic",
+                      "name": "sensor rear right Fe-Ma",
+                      "object": [
+                        {
+                          "name": "rear right Fe-Ma"
+                        }
+                      ],
+                      "y": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "20.0",
+                                  "min": "-5.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "z": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "20",
+                                  "min": "-30"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "-1",
+                                  "min": "1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "sensor front left Fe-Ti",
+                      "object": [
+                        {
+                          "name": "front left Fe-Ti"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10.0",
+                          "min": "-15.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "sensor front right Fe-Ti",
+                      "object": [
+                        {
+                          "name": "front right Fe-Ti"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "10.0",
+                          "min": "-15.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "sensor centre left Fe-Ti",
+                      "object": [
+                        {
+                          "name": "centre left Fe-Ti"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-2.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "sensor centre right Fe-Ti",
+                      "object": [
+                        {
+                          "name": "centre right Fe-Ti"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-2.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "sensor rear left Fe-Ti",
+                      "object": [
+                        {
+                          "name": "rear left Fe-Ti"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "27.5",
+                          "min": "-5.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "sensor rear right Fe-Ti",
+                      "object": [
+                        {
+                          "name": "rear right Fe-Ti"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "27.5",
+                          "min": "-5.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "sensor front left Ti-Ta",
+                      "object": [
+                        {
+                          "name": "front left Ti-Ta"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "5.0",
+                          "min": "-30.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "sensor front right Ti-Ta",
+                      "object": [
+                        {
+                          "name": "front right Ti-Ta"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "5.0",
+                          "min": "-30.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "sensor centre left Ti-Ta",
+                      "object": [
+                        {
+                          "name": "centre left Ti-Ta"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "5.0",
+                          "min": "-30.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "sensor centre right Ti-Ta",
+                      "object": [
+                        {
+                          "name": "centre right Ti-Ta"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "30.0",
+                          "min": "-5.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "sensor rear left Ti-Ta",
+                      "object": [
+                        {
+                          "name": "rear left Ti-Ta"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "20.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "sensor rear right Ti-Ta",
+                      "object": [
+                        {
+                          "name": "rear right Ti-Ta"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "20.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "generic",
+                      "name": "sensor main-rear",
+                      "object": [
+                        {
+                          "name": "main - rear"
+                        }
+                      ],
+                      "x": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "6.0",
+                                  "min": "-5.5"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "z": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "6.0",
+                                  "min": "-6.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "generic",
+                      "name": "sensor main-head",
+                      "object": [
+                        {
+                          "name": "main - head"
+                        }
+                      ],
+                      "x": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "5.0",
+                                  "min": "-4.5"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "z": [
+                        {
+                          "type": "angular",
+                          "deflection": [
+                            {
+                              "domain": [
+                                {
+                                  "max": "5.0",
+                                  "min": "-5.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "femur front left contact sensor",
+                      "object": [
+                        {
+                          "name": "femur front left"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "femur front right contact sensor",
+                      "object": [
+                        {
+                          "name": "femur front right"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "femur centre left contact sensor",
+                      "object": [
+                        {
+                          "name": "femur centre left"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "femur centre right contact sensor",
+                      "object": [
+                        {
+                          "name": "femur centre right"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "femur rear left contact sensor",
+                      "object": [
+                        {
+                          "name": "femur rear left"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "femur rear right contact sensor",
+                      "object": [
+                        {
+                          "name": "femur rear right"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "position",
+                      "name": "xyz position main",
+                      "object": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "orientation",
+                      "name": "xyz orientation main",
+                      "object": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "ov",
+                      "name": "main body velocity",
+                      "object": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "false",
+                          "y": "true",
+                          "z": "false"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "traces": [
+        {
+          "trace": [
+            {
+              "length": "5",
+              "max": "100",
+              "particles": "false",
+              "target": "main",
+              "init": [
+                {
+                  "colour": "7efaca",
+                  "size": "0.05"
+                }
+              ],
+              "final": [
+                {
+                  "colour": "7efaca",
+                  "size": "0.00"
+                }
+              ],
+              "offset": [
+                {
+                  "local": "false",
+                  "z": "0.75"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "logging": [
+        {
+          "sensor": [
+            {
+              "target": "sensor front left Fe-Ma",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor front right Fe-Ma",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor centre left Fe-Ma",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor centre right Fe-Ma",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor rear left Fe-Ma",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor rear right Fe-Ma",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor front left Fe-Ti",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor front right Fe-Ti",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor centre left Fe-Ti",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor centre right Fe-Ti",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor rear left Fe-Ti",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor rear right Fe-Ti",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor front left Ti-Ta",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor front right Ti-Ta",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor centre left Ti-Ta",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor centre right Ti-Ta",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor rear left Ti-Ta",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor rear right Ti-Ta",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor main-rear",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "sensor main-head",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "femur front left contact sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "femur front right contact sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "femur centre left contact sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "femur centre right contact sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "femur rear left contact sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "femur rear right contact sensor",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "main body velocity",
+              "external": [
+                {}
+              ]
+            },
+            {
+              "target": "xyz position main",
+              "external": [
+                {}
+              ]
+            }
+          ],
+          "actuator": [
+            {
+              "target": "front left Fe-Ma",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "front right Fe-Ma",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "centre left Fe-Ma",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "centre right Fe-Ma",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "rear left Fe-Ma",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "rear right Fe-Ma",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "front left Fe-Ti",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "front right Fe-Ti",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "centre left Fe-Ti",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "centre right Fe-Ti",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "rear left Fe-Ti",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "rear right Fe-Ti",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "front left Ti-Ta",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "front right Ti-Ta",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "centre left Ti-Ta",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "centre right Ti-Ta",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "rear left Ti-Ta",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "rear right Ti-Ta",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "main - rear",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            },
+            {
+              "target": "main - head",
+              "external": [
+                {}
+              ],
+              "desired": [
+                {}
+              ]
+            }
+          ],
+          "file": [
+            {
+              "date": "false",
+              "name": "logs/sensors",
+              "target": [
+                {
+                  "name": "sensor front left Fe-Ma"
+                },
+                {
+                  "name": "sensor front right Fe-Ma"
+                },
+                {
+                  "name": "sensor centre left Fe-Ma"
+                },
+                {
+                  "name": "sensor centre right Fe-Ma"
+                },
+                {
+                  "name": "sensor rear left Fe-Ma"
+                },
+                {
+                  "name": "sensor rear right Fe-Ma"
+                },
+                {
+                  "name": "sensor front left Fe-Ti"
+                },
+                {
+                  "name": "sensor front right Fe-Ti"
+                },
+                {
+                  "name": "sensor centre left Fe-Ti"
+                },
+                {
+                  "name": "sensor centre right Fe-Ti"
+                },
+                {
+                  "name": "sensor rear left Fe-Ti"
+                },
+                {
+                  "name": "sensor rear right Fe-Ti"
+                },
+                {
+                  "name": "sensor front left Ti-Ta"
+                },
+                {
+                  "name": "sensor front right Ti-Ta"
+                },
+                {
+                  "name": "sensor centre left Ti-Ta"
+                },
+                {
+                  "name": "sensor centre right Ti-Ta"
+                },
+                {
+                  "name": "sensor rear left Ti-Ta"
+                },
+                {
+                  "name": "sensor rear right Ti-Ta"
+                },
+                {
+                  "name": "sensor main-rear"
+                },
+                {
+                  "name": "sensor main-head"
+                },
+                {
+                  "name": "femur front left contact sensor"
+                },
+                {
+                  "name": "femur front right contact sensor"
+                },
+                {
+                  "name": "femur centre left contact sensor"
+                },
+                {
+                  "name": "femur centre right contact sensor"
+                },
+                {
+                  "name": "femur rear left contact sensor"
+                },
+                {
+                  "name": "femur rear right contact sensor"
+                }
+              ]
+            },
+            {
+              "date": "false",
+              "name": "logs/main_body_velocities",
+              "target": [
+                {
+                  "name": "main body velocity"
+                }
+              ]
+            },
+            {
+              "date": "false",
+              "name": "logs/main_body_position",
+              "target": [
+                {
+                  "name": "xyz position main"
+                }
+              ]
+            },
+            {
+              "date": "false",
+              "name": "logs/actuators",
+              "target": [
+                {
+                  "name": "front left Fe-Ma"
+                },
+                {
+                  "name": "front right Fe-Ma"
+                },
+                {
+                  "name": "centre left Fe-Ma"
+                },
+                {
+                  "name": "centre right Fe-Ma"
+                },
+                {
+                  "name": "rear left Fe-Ma"
+                },
+                {
+                  "name": "rear right Fe-Ma"
+                },
+                {
+                  "name": "front left Fe-Ti"
+                },
+                {
+                  "name": "front right Fe-Ti"
+                },
+                {
+                  "name": "centre left Fe-Ti"
+                },
+                {
+                  "name": "centre right Fe-Ti"
+                },
+                {
+                  "name": "rear left Fe-Ti"
+                },
+                {
+                  "name": "rear right Fe-Ti"
+                },
+                {
+                  "name": "front left Ti-Ta"
+                },
+                {
+                  "name": "front right Ti-Ta"
+                },
+                {
+                  "name": "centre left Ti-Ta"
+                },
+                {
+                  "name": "centre right Ti-Ta"
+                },
+                {
+                  "name": "rear left Ti-Ta"
+                },
+                {
+                  "name": "rear right Ti-Ta"
+                },
+                {
+                  "name": "main - rear"
+                },
+                {
+                  "name": "main - head"
+                }
+              ]
+            }
+          ],
+          "blender": [
+            {
+              "cfg": "logs/ralf.hexapod.cfg",
+              "framerate": "50",
+              "name": "logs/ralf.hexapod.csv"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/hexapod_shadow_test.json
+++ b/xml/hexapod_shadow_test.json
@@ -1,0 +1,3227 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "200"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "capture": "false",
+              "follow": "true",
+              "name": "main",
+              "show": "true",
+              "resolution": [
+                {
+                  "name": "720p"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "7.00",
+                      "y": "0.00",
+                      "z": "3.5"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.0",
+                      "z": "1.5"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "800000",
+                      "font": "Time",
+                      "size": "24"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "800000",
+                      "font": "Robot",
+                      "size": "24"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.0"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "main"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "name": "env",
+          "ground": [
+            {
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGround"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "box": [
+            {
+              "name": "obstacle",
+              "dimension": [
+                {
+                  "depth": "0.15",
+                  "height": "1.2",
+                  "width": "1.5"
+                }
+              ],
+              "pose": [
+                {
+                  "alpha": "0",
+                  "beta": "0",
+                  "gamma": "90",
+                  "x": "-0.95",
+                  "y": "2.25",
+                  "z": "0.6"
+                }
+              ],
+              "visualisation": [
+                {
+                  "first": [
+                    {
+                      "name": "SimpleWhite"
+                    }
+                  ],
+                  "second": [
+                    {
+                      "name": "SimpleWhite"
+                    }
+                  ],
+                  "third": [
+                    {
+                      "name": "SimpleWhite"
+                    }
+                  ],
+                  "fourth": [
+                    {
+                      "name": "SimpleWhite"
+                    }
+                  ],
+                  "fifth": [
+                    {
+                      "name": "SimpleWhite"
+                    }
+                  ],
+                  "sixth": [
+                    {
+                      "name": "SimpleWhite"
+                    }
+                  ]
+                }
+              ],
+              "physics": [
+                {
+                  "mass": [
+                    {
+                      "kg": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "hexapod",
+              "body": [
+                {
+                  "selfCollide": "true",
+                  "ply": [
+                    {
+                      "filename": "ply/h4/h4head_reduced.ply",
+                      "name": "head",
+                      "pose": [
+                        {
+                          "gamma": "-180",
+                          "x": "0.0",
+                          "y": "1.311974",
+                          "z": "0.828109"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "97.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4main_reduced.ply",
+                      "name": "main",
+                      "pose": [
+                        {
+                          "gamma": "180",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "1.194516"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "73.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4tail_reduced.ply",
+                      "name": "tail",
+                      "pose": [
+                        {
+                          "gamma": "-180",
+                          "x": "0.0",
+                          "y": "-1.611996",
+                          "z": "0.729942"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "244.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg1_reduced.ply",
+                      "name": "left L1S1",
+                      "pose": [
+                        {
+                          "alpha": "-33.95327",
+                          "beta": "0",
+                          "gamma": "-45.703818",
+                          "x": "-0.369519",
+                          "y": "0.184943",
+                          "z": "0.777272"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "9.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg2_reduced.ply",
+                      "name": "left L1S2",
+                      "pose": [
+                        {
+                          "alpha": "-33.95327",
+                          "beta": "0.0",
+                          "gamma": "-151.601909",
+                          "x": "-0.707165",
+                          "y": "0.372142",
+                          "z": "0.828558"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "6.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg3_reduced.ply",
+                      "name": "left L1S3",
+                      "pose": [
+                        {
+                          "alpha": "-96.185224",
+                          "beta": "0.0",
+                          "gamma": "-151.601909",
+                          "x": "-1.079545",
+                          "y": "1.060895",
+                          "z": "0.870632"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg4.ply",
+                      "name": "left L1S4",
+                      "pose": [
+                        {
+                          "alpha": "54.424669",
+                          "beta": "-180",
+                          "gamma": "28.39813",
+                          "x": "-1.466908",
+                          "y": "1.777365",
+                          "z": "0.273804"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg1_reduced.ply",
+                      "name": "right L1S1",
+                      "pose": [
+                        {
+                          "alpha": "-39.064833",
+                          "beta": "0.0",
+                          "gamma": "30.623471",
+                          "x": "0.384198",
+                          "y": "0.118267",
+                          "z": "0.803203"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "9.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg2_reduced.ply",
+                      "name": "right L1S2",
+                      "pose": [
+                        {
+                          "alpha": "-39.064847",
+                          "beta": "0.0",
+                          "gamma": "156.274701",
+                          "x": "0.648176",
+                          "y": "0.246003",
+                          "z": "0.907809"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "6.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg3_reduced.ply",
+                      "name": "right L1S3",
+                      "pose": [
+                        {
+                          "alpha": "-106.373448",
+                          "beta": "0.0",
+                          "gamma": "156.274646",
+                          "x": "0.971616",
+                          "y": "0.981933",
+                          "z": "1.045528"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg1seg4.ply",
+                      "name": "right L1S4",
+                      "pose": [
+                        {
+                          "alpha": "-106.373448",
+                          "beta": "0.0",
+                          "gamma": "156.27466",
+                          "x": "1.281028",
+                          "y": "1.685947",
+                          "z": "0.365667"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg1_reduced.ply",
+                      "name": "left L2S1",
+                      "pose": [
+                        {
+                          "alpha": "-113.937282",
+                          "beta": "0.0",
+                          "gamma": "135.823052",
+                          "x": "-0.2577",
+                          "y": "-0.115553",
+                          "z": "0.724711"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg2_reduced.ply",
+                      "name": "left L2S2",
+                      "pose": [
+                        {
+                          "alpha": "-31.877268",
+                          "beta": "0.0",
+                          "gamma": "135.823052",
+                          "x": "-0.54434",
+                          "y": "-0.410551",
+                          "z": "0.962445"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "6.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg3_reduced.ply",
+                      "name": "left L2S3",
+                      "pose": [
+                        {
+                          "alpha": "33.760754",
+                          "beta": "0.0",
+                          "gamma": "135.823052",
+                          "x": "-1.07631",
+                          "y": "-0.957955",
+                          "z": "1.211122"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg4.ply",
+                      "name": "left L2S4",
+                      "pose": [
+                        {
+                          "alpha": "34.475137",
+                          "beta": "0.0",
+                          "gamma": "135.823052",
+                          "x": "-1.63247",
+                          "y": "-1.530336",
+                          "z": "0.434763"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg1_reduced.ply",
+                      "name": "right L2S1",
+                      "pose": [
+                        {
+                          "alpha": "-113.937282",
+                          "beta": "0.0",
+                          "gamma": "-135.823052",
+                          "x": "0.2577",
+                          "y": "-0.115553",
+                          "z": "0.724711"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg2_reduced.ply",
+                      "name": "right L2S2",
+                      "pose": [
+                        {
+                          "alpha": "-31.877268",
+                          "beta": "0.0",
+                          "gamma": "-135.823052",
+                          "x": "0.54434",
+                          "y": "-0.410551",
+                          "z": "0.962445"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "6.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg3_reduced.ply",
+                      "name": "right L2S3",
+                      "pose": [
+                        {
+                          "alpha": "33.760754",
+                          "beta": "0.0",
+                          "gamma": "-135.823052",
+                          "x": "1.07631",
+                          "y": "-0.957955",
+                          "z": "1.211122"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "3.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg2seg4.ply",
+                      "name": "right L2S4",
+                      "pose": [
+                        {
+                          "alpha": "34.475137",
+                          "beta": "0.0",
+                          "gamma": "-135.823052",
+                          "x": "1.63247",
+                          "y": "-1.530336",
+                          "z": "0.434763"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg1_reduced.ply",
+                      "name": "left L3S1",
+                      "pose": [
+                        {
+                          "alpha": "-74.274441",
+                          "beta": "0.0",
+                          "gamma": "146.885062",
+                          "x": "-0.2291",
+                          "y": "-0.630977",
+                          "z": "0.660947"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "5.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg2_reduced.ply",
+                      "name": "left L3S2",
+                      "pose": [
+                        {
+                          "alpha": "-35.061116",
+                          "beta": "0.0",
+                          "gamma": "146.885062",
+                          "x": "-0.52851",
+                          "y": "-1.090006",
+                          "z": "1.031232"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "9.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg3_reduced.ply",
+                      "name": "left L3S3",
+                      "pose": [
+                        {
+                          "alpha": "46.017221",
+                          "beta": "0.0",
+                          "gamma": "146.885062",
+                          "x": "-1.09468",
+                          "y": "-1.958001",
+                          "z": "1.332172"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "4.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg4.ply",
+                      "name": "left L3S4",
+                      "pose": [
+                        {
+                          "alpha": "46.017225",
+                          "beta": "0.0",
+                          "gamma": "146.885062",
+                          "x": "-1.76085",
+                          "y": "-2.979317",
+                          "z": "0.467886"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg1_reduced.ply",
+                      "name": "right L3S1",
+                      "pose": [
+                        {
+                          "alpha": "-74.274441",
+                          "beta": "0.0",
+                          "gamma": "-146.885062",
+                          "x": "0.2291",
+                          "y": "-0.630977",
+                          "z": "0.660947"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "5.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg2_reduced.ply",
+                      "name": "right L3S2",
+                      "pose": [
+                        {
+                          "alpha": "-35.061116",
+                          "beta": "0.0",
+                          "gamma": "-146.885062",
+                          "x": "0.52851",
+                          "y": "-1.090006",
+                          "z": "1.031232"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "9.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg3_reduced.ply",
+                      "name": "right L3S3",
+                      "pose": [
+                        {
+                          "alpha": "46.017221",
+                          "beta": "0.0",
+                          "gamma": "-146.885062",
+                          "x": "1.09468",
+                          "y": "-1.958001",
+                          "z": "1.332172"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "4.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "filename": "ply/h4/h4leg3seg4.ply",
+                      "name": "right L3S4",
+                      "pose": [
+                        {
+                          "alpha": "46.017225",
+                          "beta": "0.0",
+                          "gamma": "-146.885062",
+                          "x": "1.76085",
+                          "y": "-2.979317",
+                          "z": "0.467886"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "YARS/Gray"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "1.0"
+                            }
+                          ],
+                          "friction": [
+                            {
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actuators": [
+                {
+                  "fixed": [
+                    {
+                      "name": "main head",
+                      "source": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "head"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "main tail",
+                      "source": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "tail"
+                        }
+                      ]
+                    }
+                  ],
+                  "hinge": [
+                    {
+                      "mode": "active",
+                      "name": "right main - L1S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L1S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "0.108318",
+                          "z": "0.288676"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L1S1 - L1S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L1S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L1S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "0.46333",
+                          "z": "0.011461"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L1S2 - L1S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L1S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L1S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.348007",
+                          "z": "0.242132"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L1S3 - L1S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L1S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L1S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.481949",
+                          "z": "0.262414"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left main - L1S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L1S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "0.108318",
+                          "z": "0.288676"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L1S1 - L1S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L1S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L1S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "0.46333",
+                          "z": "0.011461"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L1S2 - L1S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L1S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L1S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.348007",
+                          "z": "0.242132"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L1S3 - L1S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L1S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L1S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.481949",
+                          "z": "0.262414"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right main - L2S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L2S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "-0.083263",
+                          "z": "-0.123404"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L2S1 - L2S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L2S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L2S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "-0.094742",
+                          "z": "-0.491264"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L2S2 - L2S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L2S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L2S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.165596",
+                          "z": "0.423891"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L2S3 - L2S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L2S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L2S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.052062",
+                          "z": "0.556805"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left main - L2S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L2S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "-0.083263",
+                          "z": "-0.123404"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L2S1 - L2S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L2S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L2S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "-0.094742",
+                          "z": "-0.491264"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L2S2 - L2S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L2S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L2S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.165596",
+                          "z": "0.423891"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L2S3 - L2S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L2S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L2S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.052062",
+                          "z": "0.556805"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right main - L3S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L3S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "-0.157125",
+                          "z": "-0.127871"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L3S1 - L3S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L3S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L3S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "-0.040014",
+                          "z": "-0.606707"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L3S2 - L3S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L3S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L3S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.156881",
+                          "z": "0.615627"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "right L3S3 - L3S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "right L3S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "right L3S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.066215",
+                          "z": "0.764271"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left main - L3S1",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L3S1"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "alpha": "90",
+                          "x": "0.0",
+                          "y": "-0.157125",
+                          "z": "-0.127871"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L3S1 - L3S2",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L3S2"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L3S1"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "gamma": "90",
+                          "x": "0.0",
+                          "y": "-0.040014",
+                          "z": "-0.606707"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L3S2 - L3S3",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L3S3"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L3S2"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.156881",
+                          "z": "0.615627"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "mode": "active",
+                      "name": "left L3S3 - L3S4",
+                      "type": "angular",
+                      "source": [
+                        {
+                          "name": "left L3S4"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "left L3S3"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "6000.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "-0.066215",
+                          "z": "0.764271"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "pid": [
+                        {
+                          "d": "0.0",
+                          "i": "0.0",
+                          "p": "0.9",
+                          "size": "10"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "#children": [
+                    {
+                      "#tag": "deflection",
+                      "name": "right main - L1S1 sensor",
+                      "object": [
+                        {
+                          "name": "right main - L1S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L1S1 - L1S2 sensor",
+                      "object": [
+                        {
+                          "name": "right L1S1 - L1S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L1S2 - L1S3 sensor",
+                      "object": [
+                        {
+                          "name": "right L1S2 - L1S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L1S3 - L1S4 sensor",
+                      "object": [
+                        {
+                          "name": "right L1S3 - L1S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "right L1S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "right L1S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left main - L1S1 sensor",
+                      "object": [
+                        {
+                          "name": "left main - L1S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L1S1 - L1S2 sensor",
+                      "object": [
+                        {
+                          "name": "left L1S1 - L1S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L1S2 - L1S3 sensor",
+                      "object": [
+                        {
+                          "name": "left L1S2 - L1S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L1S3 - L1S4 sensor",
+                      "object": [
+                        {
+                          "name": "left L1S3 - L1S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "left L1S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "left L1S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right main - L2S1 sensor",
+                      "object": [
+                        {
+                          "name": "right main - L2S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L2S1 - L2S2 sensor",
+                      "object": [
+                        {
+                          "name": "right L2S1 - L2S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L2S2 - L2S3 sensor",
+                      "object": [
+                        {
+                          "name": "right L2S2 - L2S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L2S3 - L2S4 sensor",
+                      "object": [
+                        {
+                          "name": "right L2S3 - L2S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "right L2S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "right L2S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left main - L2S1 sensor",
+                      "object": [
+                        {
+                          "name": "left main - L2S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L2S1 - L2S2 sensor",
+                      "object": [
+                        {
+                          "name": "left L2S1 - L2S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L2S2 - L2S3 sensor",
+                      "object": [
+                        {
+                          "name": "left L2S2 - L2S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L2S3 - L2S4 sensor",
+                      "object": [
+                        {
+                          "name": "left L2S3 - L2S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "left L2S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "left L2S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right main - L3S1 sensor",
+                      "object": [
+                        {
+                          "name": "right main - L3S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L3S1 - L3S2 sensor",
+                      "object": [
+                        {
+                          "name": "right L3S1 - L3S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-85.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "-1",
+                          "min": "+1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L3S2 - L3S3 sensor",
+                      "object": [
+                        {
+                          "name": "right L3S2 - L3S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "right L3S3 - L3S4 sensor",
+                      "object": [
+                        {
+                          "name": "right L3S3 - L3S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "right L3S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "right L3S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left main - L3S1 sensor",
+                      "object": [
+                        {
+                          "name": "left main - L3S1"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "45.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L3S1 - L3S2 sensor",
+                      "object": [
+                        {
+                          "name": "left L3S1 - L3S2"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "85.0",
+                          "min": "-25.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L3S2 - L3S3 sensor",
+                      "object": [
+                        {
+                          "name": "left L3S2 - L3S3"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "deflection",
+                      "name": "left L3S3 - L3S4 sensor",
+                      "object": [
+                        {
+                          "name": "left L3S3 - L3S4"
+                        }
+                      ],
+                      "domain": [
+                        {
+                          "max": "25.0",
+                          "min": "-45.0"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "1",
+                          "min": "-1"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "binaryContact",
+                      "name": "left L3S4 contact sensor",
+                      "object": [
+                        {
+                          "name": "left L3S4"
+                        }
+                      ]
+                    },
+                    {
+                      "#tag": "position",
+                      "name": "main body position",
+                      "object": [
+                        {
+                          "name": "main"
+                        }
+                      ],
+                      "coordinates": [
+                        {
+                          "x": "true",
+                          "y": "true",
+                          "z": "true"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/joints/generic_angular.json
+++ b/xml/joints/generic_angular.json
@@ -1,0 +1,359 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.40",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Generic Force",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "3.00",
+                      "y": "3.00",
+                      "z": "3"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Generic test",
+              "body": [
+                {
+                  "box": [
+                    {
+                      "name": "base",
+                      "dimension": [
+                        {
+                          "depth": "1.0",
+                          "height": "0.5",
+                          "width": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0",
+                          "z": "0.25"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "first": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "second": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "third": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "fourth": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "fifth": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "sixth": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "moving part",
+                      "dimension": [
+                        {
+                          "depth": "0.5",
+                          "height": "0.5",
+                          "width": "0.5"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0",
+                          "z": "1.25"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "first": [
+                            {
+                              "name": "YARS/Red"
+                            }
+                          ],
+                          "second": [
+                            {
+                              "name": "YARS/Red"
+                            }
+                          ],
+                          "third": [
+                            {
+                              "name": "YARS/Red"
+                            }
+                          ],
+                          "fourth": [
+                            {
+                              "name": "YARS/Red"
+                            }
+                          ],
+                          "fifth": [
+                            {
+                              "name": "YARS/Red"
+                            }
+                          ],
+                          "sixth": [
+                            {
+                              "name": "YARS/Red"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actuators": [
+                {
+                  "generic": [
+                    {
+                      "name": "generic force joint",
+                      "spring": "false",
+                      "source": [
+                        {
+                          "name": "moving part"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "base"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "rotational": [
+                        {
+                          "x": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "100.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "0.5"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "45.0",
+                                  "min": "-45.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ],
+                          "y": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "100.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "0.5"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "45.0",
+                                  "min": "-45.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ],
+                          "z": [
+                            {
+                              "mode": "active",
+                              "type": "angular",
+                              "force": [
+                                {
+                                  "max": "100.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "0.5"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "45.0",
+                                  "min": "-45.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Sine"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/joints/generic_force.json
+++ b/xml/joints/generic_force.json
@@ -1,0 +1,359 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "100",
+          "solver": [
+            {
+              "iterations": "10"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Generic Force",
+              "show": "true",
+              "size": [
+                {
+                  "height": "800",
+                  "width": "800"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "3.00",
+                      "y": "3.00",
+                      "z": "3"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.01",
+                      "z": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Generic test",
+              "body": [
+                {
+                  "box": [
+                    {
+                      "name": "base",
+                      "dimension": [
+                        {
+                          "depth": "1.0",
+                          "height": "0.5",
+                          "width": "1.0"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0",
+                          "z": "0.25"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "first": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "second": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "third": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "fourth": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "fifth": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "sixth": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "moving part",
+                      "dimension": [
+                        {
+                          "depth": "0.5",
+                          "height": "0.5",
+                          "width": "0.5"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0",
+                          "y": "0",
+                          "z": "1.25"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "first": [
+                            {
+                              "name": "YARS/Red"
+                            }
+                          ],
+                          "second": [
+                            {
+                              "name": "YARS/Red"
+                            }
+                          ],
+                          "third": [
+                            {
+                              "name": "YARS/Red"
+                            }
+                          ],
+                          "fourth": [
+                            {
+                              "name": "YARS/Red"
+                            }
+                          ],
+                          "fifth": [
+                            {
+                              "name": "YARS/Red"
+                            }
+                          ],
+                          "sixth": [
+                            {
+                              "name": "YARS/Red"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actuators": [
+                {
+                  "generic": [
+                    {
+                      "name": "generic force joint",
+                      "spring": "false",
+                      "source": [
+                        {
+                          "name": "moving part"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "base"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "0.0"
+                        }
+                      ],
+                      "rotational": [
+                        {
+                          "x": [
+                            {
+                              "mode": "active",
+                              "type": "force",
+                              "force": [
+                                {
+                                  "max": "100.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "0.5"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "45.0",
+                                  "min": "-45.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ],
+                          "y": [
+                            {
+                              "mode": "active",
+                              "type": "force",
+                              "force": [
+                                {
+                                  "max": "100.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "0.5"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "45.0",
+                                  "min": "-45.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ],
+                          "z": [
+                            {
+                              "mode": "active",
+                              "type": "force",
+                              "force": [
+                                {
+                                  "max": "100.0"
+                                }
+                              ],
+                              "velocity": [
+                                {
+                                  "max": "0.5"
+                                }
+                              ],
+                              "deflection": [
+                                {
+                                  "max": "45.0",
+                                  "min": "-45.0"
+                                }
+                              ],
+                              "mapping": [
+                                {
+                                  "max": "1",
+                                  "min": "-1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "10",
+                  "module": "Sine"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/muscle.json
+++ b/xml/muscle.json
@@ -1,0 +1,442 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "1000",
+          "solver": [
+            {
+              "iterations": "100"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Braiternberg",
+              "show": "true",
+              "size": [
+                {
+                  "height": "600",
+                  "width": "600"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "3.00",
+                      "y": "0.00",
+                      "z": "2.0"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.00",
+                      "z": "1.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "swinging body"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Muscle 3",
+              "body": [
+                {
+                  "sphere": [
+                    {
+                      "name": "source body",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.10"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "y": "0.0",
+                          "z": "2.00"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Circuit/Top/Green"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "destination body",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.10"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.5",
+                          "y": "0.5",
+                          "z": "1.5"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Circuit/Top/Green"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actuators": [
+                {
+                  "muscle": [
+                    {
+                      "cfm": "0.1",
+                      "erp": "1.0",
+                      "friction": "0.00001",
+                      "name": "muscle",
+                      "visualise": "true",
+                      "source": [
+                        {
+                          "name": "source body"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "destination body"
+                        }
+                      ],
+                      "srcAnchor": [
+                        {
+                          "sphere": [
+                            {
+                              "name": "source anchor",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.05"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "-0.1"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Yellow"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.01"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "dstAnchor": [
+                        {
+                          "sphere": [
+                            {
+                              "name": "destination anchor",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.025"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.1"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Blue"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.01"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "2.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "0.5",
+                          "min": "-0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "0"
+                        }
+                      ],
+                      "lengthComponent": [
+                        {
+                          "c": "5.0",
+                          "optimalLength": "1.0",
+                          "use": "true",
+                          "w": "1.5"
+                        }
+                      ],
+                      "velocityComponent": [
+                        {
+                          "K": "1.5",
+                          "N": "1.5",
+                          "maxVelocity": "-3.5",
+                          "use": "false"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "top": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "bottom": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ],
+                          "body": [
+                            {
+                              "name": "YARS/Blue"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "500",
+                  "module": "SquareWave",
+                  "parameter": [
+                    {
+                      "name": "min",
+                      "value": "0.0"
+                    },
+                    {
+                      "name": "max",
+                      "value": "1.0"
+                    },
+                    {
+                      "name": "period",
+                      "value": "2500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/muscle_tcpip.json
+++ b/xml/muscle_tcpip.json
@@ -1,0 +1,494 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "1000",
+          "solver": [
+            {
+              "iterations": "100"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "follow": "false",
+              "name": "Braiternberg",
+              "show": "true",
+              "size": [
+                {
+                  "height": "600",
+                  "width": "600"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "3.00",
+                      "y": "0.00",
+                      "z": "2.0"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.00",
+                      "z": "1.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "swinging body"
+                }
+              ]
+            }
+          ],
+          "visualise": [
+            {
+              "joints": [
+                {
+                  "height": "0.5",
+                  "radius": "0.01"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Muscle",
+              "body": [
+                {
+                  "sphere": [
+                    {
+                      "name": "source body",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.10"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "y": "0.0",
+                          "z": "2.00"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Circuit/Top/Green"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "destination body",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.10"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.5",
+                          "y": "0.5",
+                          "z": "1.5"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Circuit/Top/Green"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actuators": [
+                {
+                  "muscle": [
+                    {
+                      "cfm": "0.1",
+                      "erp": "1.0",
+                      "friction": "0.00001",
+                      "name": "muscle",
+                      "visualise": "true",
+                      "source": [
+                        {
+                          "name": "source body"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "destination body"
+                        }
+                      ],
+                      "srcAnchor": [
+                        {
+                          "sphere": [
+                            {
+                              "name": "source anchor",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.05"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "-0.1"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Yellow"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.01"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "dstAnchor": [
+                        {
+                          "sphere": [
+                            {
+                              "name": "destination anchor",
+                              "visualise": "true",
+                              "dimension": [
+                                {
+                                  "radius": "0.05"
+                                }
+                              ],
+                              "pose": [
+                                {
+                                  "x": "0.0",
+                                  "y": "0.0",
+                                  "z": "0.1"
+                                }
+                              ],
+                              "visualisation": [
+                                {
+                                  "texture": [
+                                    {
+                                      "name": "Chain/Circuit/Top/Blue"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "physics": [
+                                {
+                                  "mass": [
+                                    {
+                                      "kg": "0.01"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "2.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "0.5",
+                          "min": "-0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "0"
+                        }
+                      ],
+                      "lengthComponent": [
+                        {
+                          "c": "5.0",
+                          "optimalLength": "1.0",
+                          "use": "true",
+                          "w": "1.5"
+                        }
+                      ],
+                      "velocityComponent": [
+                        {
+                          "K": "1.5",
+                          "N": "1.5",
+                          "maxVelocity": "-3.5",
+                          "use": "true"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {
+                  "muscle": [
+                    {
+                      "name": "muscle sensor",
+                      "#children": [
+                        {
+                          "#tag": "object",
+                          "name": "muscle"
+                        },
+                        {
+                          "#tag": "domain",
+                          "max": "5.0",
+                          "min": "0"
+                        },
+                        {
+                          "#tag": "mapping",
+                          "max": "5.0",
+                          "min": "0"
+                        },
+                        {
+                          "#tag": "domain",
+                          "max": "2.0",
+                          "min": "0"
+                        },
+                        {
+                          "#tag": "mapping",
+                          "max": "2.0",
+                          "min": "0"
+                        },
+                        {
+                          "#tag": "domain",
+                          "max": "2.0",
+                          "min": "0"
+                        },
+                        {
+                          "#tag": "mapping",
+                          "max": "2.0",
+                          "min": "0"
+                        },
+                        {
+                          "#tag": "domain",
+                          "max": "2.0",
+                          "min": "-2.0"
+                        },
+                        {
+                          "#tag": "mapping",
+                          "max": "2",
+                          "min": "-2.0"
+                        },
+                        {
+                          "#tag": "domain",
+                          "max": "2.0",
+                          "min": "0"
+                        },
+                        {
+                          "#tag": "mapping",
+                          "max": "2",
+                          "min": "0"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "controller": [
+                {
+                  "frequency": "100",
+                  "module": "TCPIP",
+                  "parameter": [
+                    {
+                      "name": "port",
+                      "value": "9500"
+                    },
+                    {
+                      "name": "debug",
+                      "value": "True"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/xml/test_capture.json
+++ b/xml/test_capture.json
@@ -1,0 +1,327 @@
+{
+  "rosiml": [
+    {
+      "version": "0.8.41",
+      "simulator": [
+        {
+          "frequency": "1000",
+          "solver": [
+            {
+              "iterations": "100"
+            }
+          ]
+        }
+      ],
+      "screens": [
+        {
+          "screen": [
+            {
+              "capture": "true",
+              "follow": "false",
+              "name": "Falling Object",
+              "show": "true",
+              "size": [
+                {
+                  "height": "600",
+                  "width": "600"
+                }
+              ],
+              "camera": [
+                {
+                  "position": [
+                    {
+                      "x": "3.00",
+                      "y": "0.00",
+                      "z": "2.0"
+                    }
+                  ],
+                  "lookAt": [
+                    {
+                      "x": "0.0",
+                      "y": "0.00",
+                      "z": "1.0"
+                    }
+                  ]
+                }
+              ],
+              "osd": [
+                {
+                  "time": [
+                    {
+                      "colour": "FFFF00",
+                      "font": "Time",
+                      "size": "25"
+                    }
+                  ],
+                  "robot": [
+                    {
+                      "colour": "FFFFFF",
+                      "font": "Robot",
+                      "size": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sky": [
+            {
+              "name": "YARS/CloudySky"
+            }
+          ],
+          "cameras": [
+            {
+              "orbit": [
+                {
+                  "speed": "0.5",
+                  "lookAtX": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtY": [
+                    {
+                      "d": "0.002",
+                      "i": "0.001",
+                      "p": "0.05"
+                    }
+                  ],
+                  "lookAtZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "1.0"
+                    }
+                  ],
+                  "fromX": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromY": [
+                    {
+                      "d": "0.0002",
+                      "i": "0.0001",
+                      "p": "0.01"
+                    }
+                  ],
+                  "fromZ": [
+                    {
+                      "d": "0.0",
+                      "i": "0.0",
+                      "p": "0.0"
+                    }
+                  ]
+                }
+              ],
+              "centre": [
+                {
+                  "speed": "1.5"
+                }
+              ]
+            }
+          ],
+          "followables": [
+            {
+              "followable": [
+                {
+                  "name": "swinging body"
+                }
+              ]
+            }
+          ],
+          "visualise": [
+            {
+              "joints": [
+                {
+                  "height": "0.5",
+                  "radius": "0.01"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "environment": [
+        {
+          "ground": [
+            {
+              "fixed": "true",
+              "fog": "false",
+              "visualisation": [
+                {
+                  "texture": [
+                    {
+                      "name": "YARS/DryGroundSmall"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "robots": [
+        {
+          "robot": [
+            {
+              "name": "Muscle",
+              "body": [
+                {
+                  "sphere": [
+                    {
+                      "name": "source body",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.10"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "y": "0.0",
+                          "z": "2.00"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Circuit/Top/Green"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.0"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "destination body",
+                      "visualise": "true",
+                      "dimension": [
+                        {
+                          "radius": "0.10"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "x": "0.5",
+                          "y": "0.5",
+                          "z": "1.5"
+                        }
+                      ],
+                      "visualisation": [
+                        {
+                          "texture": [
+                            {
+                              "name": "Chain/Circuit/Top/Green"
+                            }
+                          ]
+                        }
+                      ],
+                      "physics": [
+                        {
+                          "mass": [
+                            {
+                              "kg": "0.1"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actuators": [
+                {
+                  "slider": [
+                    {
+                      "mode": "passive",
+                      "name": "slider",
+                      "type": "positional",
+                      "source": [
+                        {
+                          "name": "source body"
+                        }
+                      ],
+                      "destination": [
+                        {
+                          "name": "destination body"
+                        }
+                      ],
+                      "force": [
+                        {
+                          "max": "2.0"
+                        }
+                      ],
+                      "velocity": [
+                        {
+                          "max": "0.5"
+                        }
+                      ],
+                      "pose": [
+                        {
+                          "beta": "90",
+                          "x": "0.0",
+                          "y": "0.0",
+                          "z": "-0.1"
+                        }
+                      ],
+                      "deflection": [
+                        {
+                          "max": "0.5",
+                          "min": "-0.5"
+                        }
+                      ],
+                      "mapping": [
+                        {
+                          "max": "+1",
+                          "min": "0"
+                        }
+                      ],
+                      "regular": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "limit": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ],
+                      "orthogonal": [
+                        {
+                          "damping": "1.0",
+                          "restitution": "0.7",
+                          "softness": "1.0"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "sensors": [
+                {}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Stage 2 of docs/superpowers/plans/2026-07-06-json-config-migration.md. CI now exercises JSON configs end-to-end on real runners; the XML path stays tested via a dedicated guard step until Stage 3 removes it.

## What this does
- Commits all 29 converted `.json` corpus twins (XML retained as round-trip fixtures)
- Retargets every CI path to JSON: both workflows' smoke tests, the 12-config audit corpus, both bit-exact CSV gates, the FFmpeg capture test, the perf trend, and `scripts/{sanitize-corpus,perf-measure}.sh`
- Adds a Linux "XML-path guard (until Stage 3)" step (braitenberg_logging.xml vs the same reference)
- Round-trip script hardened: converts into scratch, never touches the committed corpus, and now doubles as a corpus-drift check (committed twin must equal fresh conversion)
- LSan suppression extended to the JSON path's mirrored opening-element lifetime (`parseJsonConfig`) — same tracked leak, second call path; caught by the sanitize gate on the first all-JSON run (invisible on macOS)

## Verification
- CI green on both platforms with everything running from JSON: both CSV gates byte-identical to the same references XML produced, sanitize corpus 13/13 under ASan/UBSan/LSan, capture mp4 produced, perf trend recording
- Review independently re-ran gates, corpus, and drift spot-checks (3 twins regeneration-stable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)